### PR TITLE
fix(net): validate peer transactions before mempool insertion

### DIFF
--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -1117,6 +1117,15 @@ impl NetTask {
                                 .env
                                 .write_txn()
                                 .map_err(EnvError::from)?;
+                            // Validate the peer-supplied transaction before
+                            // accepting it into the mempool, mirroring the RPC
+                            // path (`Node::submit_transaction`). Without this,
+                            // transactions with invalid signatures / failing
+                            // balance checks are accepted and re-broadcast.
+                            let _: bitcoin::Amount = self
+                                .ctxt
+                                .state
+                                .validate_transaction(&rwtxn, &new_tx)?;
                             self.ctxt.mempool.put(&mut rwtxn, &new_tx)?;
                             rwtxn.commit().map_err(RwTxnError::from)?;
                             // broadcast

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -761,3 +761,117 @@ impl Watchable<()> for State {
         tokio_stream::wrappers::WatchStream::new(self.tip.watch().clone())
     }
 }
+
+#[cfg(test)]
+mod p2p_validation_bypass_tests {
+    use bitcoin::Amount;
+    use heed::EnvOpenOptions;
+
+    use crate::authorization::{Authorization, get_address, Signature};
+    use crate::mempool::MemPool;
+    use crate::state::State;
+    use crate::types::{
+        Address, FilledOutput, FilledOutputContent, OutPoint, OutPointKey, Output,
+        OutputContent, Transaction, Txid,
+    };
+
+    fn signing_key(seed: u8) -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn temp_env() -> sneed::Env {
+        let dir = std::env::temp_dir()
+            .join(format!("bitassets-p2p-test-{}", std::process::id()));
+        drop(std::fs::remove_dir_all(&dir));
+        std::fs::create_dir_all(&dir).expect("create temp env dir");
+        let mut opts = EnvOpenOptions::new();
+        opts.map_size(16 * 1024 * 1024)
+            .max_dbs(State::NUM_DBS + MemPool::NUM_DBS + 4);
+        unsafe { sneed::Env::open(&opts, &dir) }.expect("open env")
+    }
+
+    #[test]
+    fn p2p_path_accepts_transaction_that_validation_rejects() {
+        let env = temp_env();
+        let state = State::new(&env).expect("State::new");
+        let mempool = MemPool::new(&env).expect("MemPool::new");
+
+        let victim = signing_key(1);
+        let victim_vk = crate::types::VerifyingKey(victim.verifying_key());
+        let victim_addr: Address = get_address(&victim_vk);
+        let funding_outpoint = OutPoint::Regular {
+            txid: Txid([7u8; 32]),
+            vout: 0,
+        };
+        let funded_output = FilledOutput {
+            address: victim_addr,
+            content: FilledOutputContent::Bitcoin(crate::types::BitcoinOutputContent(
+                Amount::from_sat(100_000),
+            )),
+            memo: vec![],
+        };
+        {
+            let mut rwtxn = env.write_txn().expect("write txn");
+            state
+                .utxos
+                .put(&mut rwtxn, &OutPointKey::from(&funding_outpoint), &funded_output)
+                .expect("put utxo");
+            rwtxn.commit().expect("commit funding");
+        }
+
+        let tx = Transaction {
+            inputs: vec![funding_outpoint],
+            outputs: vec![Output {
+                address: get_address(&crate::types::VerifyingKey(signing_key(2).verifying_key())),
+                content: OutputContent::Bitcoin(crate::types::BitcoinOutputContent(
+                    Amount::from_sat(90_000),
+                )),
+                memo: vec![],
+            }],
+            memo: vec![],
+            data: None,
+        };
+
+        let forged = Authorization {
+            verifying_key: victim_vk,
+            signature: Signature(ed25519_dalek::Signature::from_bytes(&[0u8; 64])),
+        };
+        let authd_tx = crate::types::AuthorizedTransaction {
+            transaction: tx,
+            authorizations: vec![forged],
+        };
+
+        {
+            let rotxn = env.read_txn().expect("read txn");
+            let result = state.validate_transaction(&rotxn, &authd_tx);
+            eprintln!("validate_transaction(forged tx) => {result:?}");
+            assert!(result.is_err(), "validator must reject the forged-sig tx: {result:?}");
+            assert!(
+                format!("{result:?}").to_lowercase().contains("authoriz"),
+                "rejection must be an authorization error, got {result:?}"
+            );
+        }
+
+        {
+            let mut rwtxn = env.write_txn().expect("write txn");
+            mempool
+                .put(&mut rwtxn, &authd_tx)
+                .expect("mempool.put accepted the invalid tx (the bug)");
+            rwtxn.commit().expect("commit mempool");
+        }
+
+        {
+            let rotxn = env.read_txn().expect("read txn");
+            let in_mempool = mempool.take_all(&rotxn).expect("take_all");
+            assert_eq!(
+                in_mempool.len(),
+                1,
+                "the forged-signature tx must be sitting in the mempool"
+            );
+            assert_eq!(
+                in_mempool[0].transaction.txid(),
+                authd_tx.transaction.txid(),
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The P2P `NewTransaction` handler in `lib/node/net_task.rs` inserted peer-supplied
transactions into the mempool via `MemPool::put` **without** first running
`State::validate_transaction`. The RPC submission path (`Node::submit_transaction`)
*does* validate. Because of this asymmetry, a transaction received from a peer with
an **invalid signature** (or one that fails balance/fee checks) is accepted into the
mempool and **re-broadcast to all peers**, even though it can never be included in a
valid block.

Any peer can exploit this to flood the network's mempools with invalid transactions:
- network-wide mempool poisoning / wasted bandwidth (each node accepts and relays),
- non-mining nodes never run the template builder, so the junk stays resident in
  their mempools indefinitely (unbounded growth from free, keyless traffic).

(The block-template path is self-healing: `Node::get_transactions` re-validates and
drops invalid txs before building a template, so they never reach a block — the
impact is relay amplification and mempool bloat, not poisoned templates.)

(Severity: network-level DoS — no direct theft, since invalid transactions are still
rejected at block-connect time.)

## Root cause

The handler opened a write txn and called `mempool.put` directly. `MemPool::put`
only guards against double-spends *within the mempool*; it does not verify
signatures, address binding, input existence, or fees.

## Fix

Run `State::validate_transaction` in the `NewTransaction` handler before
`MemPool::put`, mirroring the RPC path. One line; the `?` converts the `state::Error`
via the existing `net_task::Error::State(#[from] Box<state::Error>)` impl.

## Test

Adds `lib/state/mod.rs::p2p_validation_bypass_tests`, a runtime regression test that
funds a real UTXO, builds a transaction spending it but signs with the wrong key,
then asserts:
1. `State::validate_transaction` rejects it with an `AuthorizationError`, but
2. the bare `MemPool::put` (what the P2P handler did) accepts it and leaves the
   invalid transaction resident in the mempool.

(The test lives in `lib/state/mod.rs` rather than `lib/mempool.rs` only because the
state UTXO set used to fund the input is private to the `state` module.)

```
validate_transaction(forged tx) => Err(AuthorizationError)
test state::p2p_validation_bypass_tests::p2p_path_accepts_transaction_that_validation_rejects ... ok
test result: ok. 1 passed; 0 failed
```

## Note

This is one shared bug pattern across the LayerTwo-Labs Rust L2 stack (thunder-rust,
coinshift-rs, photon, plain-bitassets, plain-bitnames, truthcoin-dc); each repo
carries the same gap in its own `net_task.rs` and gets the same fix.
