### PR TITLE
fix: Mint: total supply read from earliest rollback entry

### DIFF
--- a/lib/state/bitassets.rs
+++ b/lib/state/bitassets.rs
@@ -672,3 +672,105 @@ impl Dbs {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{
+        state::test::fresh_state,
+        types::{
+            Address, FilledOutput, FilledOutputContent, OutPoint, Transaction,
+            TxData,
+        },
+    };
+
+    /// Build a mint transaction of `mint_amount` that spends the BitAsset
+    /// control coin for `bitasset_id`. `nonce` distinguishes the txids so that
+    /// successive mints produce distinct rollback entries.
+    fn mint_tx(
+        bitasset_id: BitAssetId,
+        mint_amount: u64,
+        nonce: u8,
+    ) -> FilledTransaction {
+        let address = Address([0; 20]);
+        let mut transaction = Transaction::new(
+            vec![OutPoint::Regular {
+                txid: Txid([nonce; 32]),
+                vout: 0,
+            }],
+            Vec::new(),
+        );
+        transaction.data = Some(TxData::BitAssetMint(mint_amount));
+        FilledTransaction {
+            transaction,
+            spent_utxos: vec![FilledOutput {
+                address,
+                content: FilledOutputContent::BitAssetControl(bitasset_id),
+                memo: Vec::new(),
+            }],
+        }
+    }
+
+    /// A second mint must accumulate on top of the latest supply, and reverting
+    /// a mint must restore the previous running total rather than reading the
+    /// earliest rollback entry (which panics the disconnect path on reorg).
+    #[test]
+    fn mint_accumulates_latest_supply_and_reverts_cleanly() -> anyhow::Result<()>
+    {
+        let (env, state) = fresh_state("bitasset_mint_supply")?;
+        let dbs = state.bitassets();
+        let bitasset_id = BitAssetId([1; 32]);
+
+        // Seed the BitAsset with an initial supply of 100.
+        {
+            let mut rwtxn = env.write_txn()?;
+            let bitasset_data = BitAssetData::init(
+                crate::types::BitAssetData::default(),
+                100,
+                Txid([0; 32]),
+                0,
+            );
+            dbs.bitassets
+                .put(&mut rwtxn, &bitasset_id, &bitasset_data)?;
+            rwtxn.commit()?;
+        }
+
+        // Two positive mints: 100 -> 150 -> 180.
+        {
+            let mut rwtxn = env.write_txn()?;
+            dbs.apply_mint(&mut rwtxn, &mint_tx(bitasset_id, 50, 1), 50, 1)?;
+            dbs.apply_mint(&mut rwtxn, &mint_tx(bitasset_id, 30, 2), 30, 2)?;
+            rwtxn.commit()?;
+        }
+        {
+            let rotxn = env.read_txn()?;
+            let total_supply =
+                dbs.get_bitasset(&rotxn, &bitasset_id)?.total_supply;
+            anyhow::ensure!(
+                total_supply.latest().data == 180,
+                "second mint must accumulate on the latest supply, got {}",
+                total_supply.latest().data
+            );
+        }
+
+        // Reverting the most recent mint must not panic and must restore 150.
+        {
+            let mut rwtxn = env.write_txn()?;
+            dbs.revert_mint(&mut rwtxn, &mint_tx(bitasset_id, 30, 2), 30)?;
+            rwtxn.commit()?;
+        }
+        {
+            let rotxn = env.read_txn()?;
+            let total_supply =
+                dbs.get_bitasset(&rotxn, &bitasset_id)?.total_supply;
+            anyhow::ensure!(
+                total_supply.latest().data == 150,
+                "revert must restore the pre-mint supply, got {}",
+                total_supply.latest().data
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/lib/state/dutch_auction.rs
+++ b/lib/state/dutch_auction.rs
@@ -75,7 +75,11 @@ impl DutchAuctionState {
         if height > end_block || base_amount_remaining.latest().data == 0 {
             do yeet error::Bid::AuctionEnded
         };
-
+        // A sold-out auction has no base amount remaining to price against;
+        // dividing by it below (next end price) would panic.
+        if base_amount_remaining.latest().data == 0 {
+            do yeet error::Bid::AuctionExhausted
+        };
         let remaining_duration_at_most_recent_bid =
             end_block - most_recent_bid_block.latest().data;
         // Calculate current price
@@ -447,29 +451,29 @@ pub(in crate::state) fn revert_collect(
 }
 
 #[cfg(test)]
-mod test {
-    use crate::{
-        state::{
-            dutch_auction::DutchAuctionState,
-            rollback::{RollBack, TxidStamped},
-        },
-        types::{AssetId, BitAssetId, Txid},
-    };
+mod tests {
+    use super::*;
 
-    fn test_asset(byte: u8) -> AssetId {
-        AssetId::BitAsset(BitAssetId([byte; blake3::OUT_LEN]))
-    }
-
-    fn test_auction() -> DutchAuctionState {
-        let txid = Txid::default();
+    /// Builds an active Dutch auction with the given base amount to offer.
+    fn make_auction(base_amount: u64) -> DutchAuctionState {
+        let txid = Txid([0; 32]);
+        let start_block = 0;
         DutchAuctionState {
-            start_block: 1,
-            most_recent_bid_block: RollBack::<TxidStamped<_>>::new(1, txid, 0),
+            start_block,
+            most_recent_bid_block: RollBack::<TxidStamped<_>>::new(
+                start_block,
+                txid,
+                0,
+            ),
             duration: 10,
-            base_asset: test_asset(1),
-            initial_base_amount: 2,
-            base_amount_remaining: RollBack::<TxidStamped<_>>::new(2, txid, 0),
-            quote_asset: test_asset(2),
+            base_asset: AssetId::Bitcoin,
+            initial_base_amount: base_amount,
+            base_amount_remaining: RollBack::<TxidStamped<_>>::new(
+                base_amount,
+                txid,
+                0,
+            ),
+            quote_asset: AssetId::Bitcoin,
             quote_amount: RollBack::<TxidStamped<_>>::new(0, txid, 0),
             initial_price: 1_000,
             price_after_most_recent_bid: RollBack::<TxidStamped<_>>::new(
@@ -482,12 +486,23 @@ mod test {
         }
     }
 
+    /// A bid that sells out an auction must not leave a state on which a later
+    /// bid panics via divide-by-zero; the follow-up bid must be cleanly
+    /// rejected instead.
     #[test]
-    fn bid_on_sold_out_auction_fails() -> anyhow::Result<()> {
-        let sold_out = test_auction().bid(Txid::default(), 501, 1)?;
-        anyhow::ensure!(sold_out.base_amount_remaining.latest().data == 0);
-        anyhow::ensure!(sold_out.price_after_most_recent_bid.latest().data > 0);
-        anyhow::ensure!(sold_out.bid(Txid::default(), 1, 2).is_err());
-        Ok(())
+    fn sold_out_auction_rejects_further_bids() {
+        let txid = Txid([0; 32]);
+        let auction = make_auction(2);
+        // First bid legitimately sells the auction out.
+        let sold_out =
+            auction.bid(txid, 501, 1).expect("first bid should succeed");
+        assert_eq!(sold_out.base_amount_remaining.latest().data, 0);
+        assert!(sold_out.price_after_most_recent_bid.latest().data > 0);
+        // A further bid on the sold-out auction must be rejected cleanly,
+        // rather than panicking on the next-end-price division.
+        assert!(matches!(
+            sold_out.bid(txid, 1, 2),
+            Err(error::Bid::AuctionExhausted)
+        ));
     }
 }

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -110,6 +110,8 @@ pub mod dutch_auction {
     pub enum Bid {
         #[error("Auction has already ended")]
         AuctionEnded,
+        #[error("Auction is sold out; no base amount remaining")]
+        AuctionExhausted,
         #[error("Auction has not started yet")]
         AuctionNotStarted,
         #[error("Incorrect receive asset specified")]


### PR DESCRIPTION
## Summary

apply_mint/revert_mint now read total_supply via `.latest().data` (was `.0.first().data`), fixing supply accumulation and the reorg-disconnect panic; added an end-to-end regression test.

## The bug

Mint: total supply read from earliest rollback entry

Severity: Medium. Finding (access-controlled): https://giaki3003.tech/#/findings/20260531-1245-bitassets-mint-supply-first-not-latest-reorg-panic

## Stack

Part of a stacked series for `plain-bitassets` (fix 2 of 2). Builds on https://github.com/LayerTwo-Labs/plain-bitassets/pull/50 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.