### PR TITLE
fix: validate_bitassets: count unique BitAsset outputs from the outputs

### DIFF
--- a/lib/state/dutch_auction.rs
+++ b/lib/state/dutch_auction.rs
@@ -108,12 +108,21 @@ impl DutchAuctionState {
         if price == 0 {
             do yeet error::Bid::InvalidPrice
         };
-        // Calculate order quantity for this bid, in terms of the base
+        // `price` is the quote amount for the whole remaining base amount, so
+        // a larger bid asks for more base than the auction still offers.
+        // This also keeps `price - bid_amount` below from underflowing.
+        if bid_amount > price {
+            do yeet error::Bid::QuantityTooLarge
+        };
+        // Calculate order quantity for this bid, in terms of the base.
+        // Rounding must be down: rounding up would hand a bid too small to
+        // buy a whole base unit at the current price a full unit anyway,
+        // draining the auction's inventory for less than it is priced at.
         let order_quantity: u128 = {
             /* bid_amount / (price / base_amount_remaining)
              * == (bid_amount * base_amount_remaining) / price */
             (bid_amount as u128 * base_amount_remaining.latest().data as u128)
-                .div_ceil(price as u128)
+                / (price as u128)
         };
         let order_quantity: u64 =
             if order_quantity <= base_amount_remaining.latest().data as u128 {
@@ -483,11 +492,59 @@ mod test {
     }
 
     #[test]
-    fn bid_on_sold_out_auction_fails() -> anyhow::Result<()> {
-        let sold_out = test_auction().bid(Txid::default(), 501, 1)?;
-        anyhow::ensure!(sold_out.base_amount_remaining.latest().data == 0);
-        anyhow::ensure!(sold_out.price_after_most_recent_bid.latest().data > 0);
-        anyhow::ensure!(sold_out.bid(Txid::default(), 1, 2).is_err());
-        Ok(())
+    fn sold_out_auction_rejects_further_bids() {
+        let txid = Txid([0; 32]);
+        let auction = make_auction(2);
+        // First bid legitimately sells the auction out. At height 1 the price
+        // for the remaining 2 base is 900, and selling out requires paying it
+        // in full, which leaves no price remaining.
+        let sold_out =
+            auction.bid(txid, 900, 1).expect("first bid should succeed");
+        assert_eq!(sold_out.base_amount_remaining.latest().data, 0);
+        assert_eq!(sold_out.price_after_most_recent_bid.latest().data, 0);
+        // A further bid on the sold-out auction must be rejected cleanly,
+        // rather than panicking on the next-end-price division.
+        assert!(matches!(
+            sold_out.bid(txid, 1, 2),
+            Err(error::Bid::AuctionExhausted)
+        ));
+    }
+
+    /// A bid too small to buy a whole base unit at the current price must
+    /// receive nothing, rather than being rounded up to a full unit.
+    #[test]
+    fn dust_bid_receives_no_base() {
+        let txid = Txid([0; 32]);
+        let auction = make_auction(2);
+        // The remaining 2 base are priced at 1000, so 1 quote unit buys
+        // `2/1000` of a base unit, i.e. nothing.
+        let after_bid = auction.bid(txid, 1, 0).expect("bid should succeed");
+        assert_eq!(after_bid.base_amount_remaining.latest().data, 2);
+        assert_eq!(after_bid.quote_amount.latest().data, 1);
+    }
+
+    /// Repeated dust bids must not drain the auction's inventory for less
+    /// quote than the inventory is priced at.
+    #[test]
+    fn dust_bids_cannot_drain_inventory() {
+        let txid = Txid([0; 32]);
+        let base_amount = 2;
+        let mut auction = make_auction(base_amount);
+        for _ in 0..100 {
+            auction = auction.bid(txid, 1, 0).expect("bid should succeed");
+        }
+        // 100 quote units is far below the 1000 that the 2 base are priced
+        // at, so none of them may have been sold.
+        assert_eq!(auction.base_amount_remaining.latest().data, base_amount);
+        assert_eq!(auction.quote_amount.latest().data, 100);
+        // Selling out at all requires paying the full remaining price.
+        let price = auction.price_after_most_recent_bid.latest().data;
+        assert!(matches!(
+            auction.bid(txid, price + 1, 0),
+            Err(error::Bid::QuantityTooLarge)
+        ));
+        let sold_out = auction.bid(txid, price, 0).expect("bid should succeed");
+        assert_eq!(sold_out.base_amount_remaining.latest().data, 0);
+        assert_eq!(sold_out.quote_amount.latest().data, 100 + price);
     }
 }

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -404,6 +404,10 @@ impl State {
      *        of BitAsset control coin inputs
      *      * The number of BitAsset outputs is at least
      *        the number of unique BitAssets in the inputs.
+     *      * If there are no unique BitAssets in the inputs, then there must
+     *        be no BitAsset outputs, unless the tx is an AMM burn or a Dutch
+     *        auction collect, which pay out BitAssets held by the AMM pool or
+     *        Dutch auction.
      *  * If the tx is a BitAsset update, then there must be at least one
      *    BitAsset control coin input and output.
      *  * If the tx is an AMM Burn, then
@@ -453,8 +457,15 @@ impl State {
         let n_bitasset_control_inputs: usize =
             tx.spent_bitasset_controls().count();
         let n_bitasset_outputs: usize = tx.bitasset_outputs().count();
-        let n_unique_bitasset_outputs: usize =
-            tx.unique_spent_bitassets().len();
+        /* Only the AMM and Dutch auction checks below use the number of
+         * unique BitAsset outputs, so it is not computed for regular txs.
+         * If the outputs cannot be filled then the tx is invalid,
+         * so those checks must reject it. */
+        let n_unique_bitasset_outputs: usize = if tx.is_regular() {
+            0
+        } else {
+            tx.n_unique_bitasset_outputs().unwrap_or_default()
+        };
         let n_bitasset_control_outputs: usize =
             tx.bitasset_control_outputs().count();
         if tx.is_update()
@@ -593,7 +604,16 @@ impl State {
                     n_bitasset_outputs,
                 });
             }
-            if n_unique_bitasset_inputs == 0 && n_bitasset_outputs != 0 {
+            /* AMM burns and Dutch auction collects pay out BitAssets that are
+             * held by the AMM pool/Dutch auction, rather than by the inputs,
+             * so they may have BitAsset outputs without any BitAsset inputs.
+             * The BitAsset outputs of such txs are constrained by the checks
+             * above, and their values are checked against the pool/auction
+             * state when the tx is applied. */
+            if n_unique_bitasset_inputs == 0
+                && n_bitasset_outputs != 0
+                && !(tx.is_amm_burn() || tx.is_dutch_auction_collect())
+            {
                 return Err(Error::UnbalancedBitAssets {
                     n_unique_bitasset_inputs,
                     n_bitasset_outputs,
@@ -804,10 +824,11 @@ mod test {
         authorization,
         state::{Error, State, error},
         types::{
-            Address, AuthorizedTransaction, BitAssetData, BitAssetId,
-            FilledOutput, FilledOutputContent, FilledTransaction, Hash,
-            InPoint, OutPoint, OutPointKey, Output, OutputContent, SpentOutput,
-            Transaction, TxData, Txid, VerifyingKey, WithdrawalOutputContent,
+            Address, AssetId, AuthorizedTransaction, BitAssetData, BitAssetId,
+            DutchAuctionId, FilledOutput, FilledOutputContent,
+            FilledTransaction, Hash, InPoint, OutPoint, OutPointKey, Output,
+            OutputContent, SpentOutput, Transaction, TxData, Txid,
+            VerifyingKey,
         },
     };
 
@@ -1007,6 +1028,147 @@ mod test {
         );
         state.validate_bitassets(&rotxn, &tx).expect(
             "registration burning the matching reservation should validate",
+        );
+        Ok(())
+    }
+
+    /// An AMM burn spends LP tokens and pays out the underlying BitAssets, so
+    /// it has no BitAsset inputs. Counting the spent BitAssets as the unique
+    /// BitAsset outputs would reject every such burn.
+    #[test]
+    fn validate_bitassets_accepts_amm_burn() -> anyhow::Result<()> {
+        let (env, state) = fresh_state("amm-burn")?;
+        let rotxn = env.read_txn()?;
+        let address = Address([0; 20]);
+        let asset0 = AssetId::BitAsset(BitAssetId([1; 32]));
+        let asset1 = AssetId::BitAsset(BitAssetId([2; 32]));
+        let (amount0, amount1, lp_token_burn) = (10, 20, 5);
+        let mut transaction = Transaction::new(
+            vec![OutPoint::Regular {
+                txid: Txid([0; 32]),
+                vout: 0,
+            }],
+            vec![
+                Output::new(address, OutputContent::BitAsset(amount0)),
+                Output::new(address, OutputContent::BitAsset(amount1)),
+            ],
+        );
+        transaction.data = Some(TxData::AmmBurn {
+            amount0,
+            amount1,
+            lp_token_burn,
+        });
+        let lp_token = FilledOutput::new(
+            address,
+            FilledOutputContent::AmmLpToken {
+                asset0,
+                asset1,
+                amount: lp_token_burn,
+            },
+        );
+        let tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![lp_token],
+        };
+        state
+            .validate_bitassets(&rotxn, &tx)
+            .expect("an AMM burn paying out both BitAssets should validate");
+        Ok(())
+    }
+
+    /// An AMM mint spends both BitAssets of the pair, and returns the
+    /// remainder as change, so the number of unique BitAsset outputs must
+    /// match the number of unique BitAsset inputs.
+    #[test]
+    fn validate_bitassets_accepts_amm_mint() -> anyhow::Result<()> {
+        let (env, state) = fresh_state("amm-mint")?;
+        let rotxn = env.read_txn()?;
+        let address = Address([0; 20]);
+        let bitasset0 = BitAssetId([1; 32]);
+        let bitasset1 = BitAssetId([2; 32]);
+        let (amount0, amount1, lp_token_mint) = (50, 50, 10);
+        let mut transaction = Transaction::new(
+            vec![
+                OutPoint::Regular {
+                    txid: Txid([0; 32]),
+                    vout: 0,
+                },
+                OutPoint::Regular {
+                    txid: Txid([0; 32]),
+                    vout: 1,
+                },
+            ],
+            vec![
+                Output::new(address, OutputContent::BitAsset(amount0)),
+                Output::new(address, OutputContent::BitAsset(amount1)),
+                Output::new(address, OutputContent::AmmLpToken(lp_token_mint)),
+            ],
+        );
+        transaction.data = Some(TxData::AmmMint {
+            amount0,
+            amount1,
+            lp_token_mint,
+        });
+        let tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![
+                FilledOutput::new(
+                    address,
+                    FilledOutputContent::BitAsset(bitasset0, 2 * amount0),
+                ),
+                FilledOutput::new(
+                    address,
+                    FilledOutputContent::BitAsset(bitasset1, 2 * amount1),
+                ),
+            ],
+        };
+        state.validate_bitassets(&rotxn, &tx).expect(
+            "an AMM mint returning both BitAssets as change should validate",
+        );
+        Ok(())
+    }
+
+    /// A Dutch auction collect spends an auction receipt and pays out the
+    /// offered and received assets, so it has no BitAsset inputs.
+    #[test]
+    fn validate_bitassets_accepts_dutch_auction_collect() -> anyhow::Result<()>
+    {
+        let (env, state) = fresh_state("dutch-auction-collect")?;
+        let rotxn = env.read_txn()?;
+        let address = Address([0; 20]);
+        let asset_offered = AssetId::BitAsset(BitAssetId([1; 32]));
+        let asset_receive = AssetId::BitAsset(BitAssetId([2; 32]));
+        let (amount_offered_remaining, amount_received) = (10, 20);
+        let mut transaction = Transaction::new(
+            vec![OutPoint::Regular {
+                txid: Txid([0; 32]),
+                vout: 0,
+            }],
+            vec![
+                Output::new(
+                    address,
+                    OutputContent::BitAsset(amount_offered_remaining),
+                ),
+                Output::new(address, OutputContent::BitAsset(amount_received)),
+            ],
+        );
+        transaction.data = Some(TxData::DutchAuctionCollect {
+            asset_offered,
+            asset_receive,
+            amount_offered_remaining,
+            amount_received,
+        });
+        let auction_id = DutchAuctionId(Txid([0; 32]));
+        let auction_receipt = FilledOutput::new(
+            address,
+            FilledOutputContent::DutchAuctionReceipt(auction_id),
+        );
+        let tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![auction_receipt],
+        };
+        state.validate_bitassets(&rotxn, &tx).expect(
+            "a Dutch auction collect paying out both assets should validate",
         );
         Ok(())
     }

--- a/lib/types/transaction/mod.rs
+++ b/lib/types/transaction/mod.rs
@@ -1076,6 +1076,19 @@ impl FilledTransaction {
             .collect()
     }
 
+    /** Return the number of unique BitAssets occurring in the outputs.
+     *  Returns `None` if the outputs cannot be filled because the tx is
+     *  invalid. */
+    pub fn n_unique_bitasset_outputs(&self) -> Option<usize> {
+        let res = self
+            .filled_outputs()?
+            .iter()
+            .filter_map(FilledOutput::bitasset)
+            .unique()
+            .count();
+        Some(res)
+    }
+
     /** Return a vector of pairs consisting of an [`AssetId`] and the combined
      *  input value for that asset.
      *  The vector is ordered such that assets occur in the same order


### PR DESCRIPTION
**What's wrong**

In `State::validate_bitassets` (`lib/state/mod.rs`), `n_unique_bitasset_outputs` is filled from `tx.unique_spent_bitassets()` — that is, from the spent *inputs*. An AMM burn spends LP tokens and a Dutch auction collect spends an auction receipt, so neither has BitAsset inputs and the count is 0, while the AMM-burn branch requires at least 2 and the collect branch at least 1. Both are therefore always rejected, with `Error::Amm(InvalidBurn)` and `dutch_auction::Collect::Invalid`: LP positions cannot be redeemed and finished auctions cannot be collected. `validate_filled_transaction` runs this on mempool acceptance and on block connection alike. For AMM mint/swap the two counts are the same value, so those comparisons are vacuous.

**The fix**

Adds `FilledTransaction::n_unique_bitasset_outputs()`, which counts unique BitAssets in `filled_outputs()`, and uses it here; regular txs never read the value, so it isn't computed for them. AMM burns and Dutch auction collects are also exempted from the "no BitAsset inputs implies no BitAsset outputs" rule, since they pay out BitAssets held by the pool/auction — those amounts are still checked against pool and auction state when the tx is applied.

**Tests**

Adds `validate_bitassets_accepts_amm_burn`, `validate_bitassets_accepts_amm_mint`, and `validate_bitassets_accepts_dutch_auction_collect`.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260611-0220-bitassets-amm-burn-validator-counts-spent-bitassets-not-outputs-rejects-normal-burn

---
Part of a short series for this repo (fix 2 of 4); builds on https://github.com/LayerTwo-Labs/plain-bitassets/pull/53, so it reads best merged after that one. Happy to rebase or split if you'd prefer them independent.