### PR TITLE
fix: MemPool::get_unconfirmed_utxos: skip outputs spent by mempool txs

### DIFF
--- a/lib/mempool.rs
+++ b/lib/mempool.rs
@@ -302,7 +302,13 @@ impl MemPool {
                     },
                 )
             })
-            .collect();
+            .try_fold(HashMap::new(), |mut utxos, (outpoint, output)| {
+                // An output spent by another mempool tx is no longer a UTXO
+                if self.spent_utxos.try_get(rotxn, &outpoint)?.is_none() {
+                    utxos.insert(outpoint, output);
+                }
+                Result::<_, Error>::Ok(utxos)
+            })?;
         Ok(res)
     }
 }

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -674,6 +674,7 @@ where
         let mut fee = bitcoin::Amount::ZERO;
         let mut returned_transactions = vec![];
         let mut spent_utxos = HashSet::new();
+        let mut swapped_amm_pairs = HashSet::new();
         for transaction in transactions {
             let inputs: HashSet<_> =
                 transaction.transaction.inputs.iter().copied().collect();
@@ -695,6 +696,17 @@ where
             let filled_transaction = self
                 .state
                 .fill_authorized_transaction(&rwtxn, transaction)?;
+            /* Each swap is validated against the pool state as it was before
+             * this block, so at most one swap per pool can be included.
+             * Later swaps on the same pool are left in the mempool, since they
+             * are still valid on their own. */
+            if let Some(amm_swap) = filled_transaction.transaction.amm_swap() {
+                let amm_pair =
+                    AmmPair::new(amm_swap.asset_spend, amm_swap.asset_receive);
+                if !swapped_amm_pairs.insert(amm_pair) {
+                    continue;
+                }
+            }
             let value_in: bitcoin::Amount = filled_transaction
                 .transaction
                 .spent_utxos

--- a/lib/state/amm.rs
+++ b/lib/state/amm.rs
@@ -1,6 +1,6 @@
 use heed::types::SerdeBincode;
 use serde::{Deserialize, Serialize};
-use sneed::{DatabaseUnique, RoDatabaseUnique, RwTxn};
+use sneed::{DatabaseUnique, RoDatabaseUnique, RoTxn, RwTxn};
 use utoipa::ToSchema;
 
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Ordered pair of [`AssetId`]s
-#[derive(Clone, Copy, Debug, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct AmmPair(AssetId, AssetId);
 
 impl AmmPair {
@@ -467,20 +467,21 @@ pub(in crate::state) fn revert_mint(
     Ok(())
 }
 
-// Apply AMM swap
-pub(in crate::state) fn apply_swap(
-    pools: &PoolsDb,
-    rwtxn: &mut RwTxn,
-    filled_tx: &FilledTransaction,
-) -> Result<(), Error> {
+/** Compute the pool state resulting from a swap, checking the declared
+ *  amount to receive against the amount computed from the pool state. */
+fn swap_pool_state(
+    pools: &RoPoolsDb,
+    rotxn: &RoTxn,
+    amm_swap: AmmSwap,
+) -> Result<(AmmPair, PoolState), Error> {
     let AmmSwap {
         asset_spend,
         asset_receive,
         amount_spend,
         amount_receive,
-    } = filled_tx.amm_swap().ok_or(Error::InvalidSwap)?;
+    } = amm_swap;
     let amm_pair = AmmPair::new(asset_spend, asset_receive);
-    let amm_pool_state = pools.try_get(rwtxn, &amm_pair)?.ok_or_else(|| {
+    let amm_pool_state = pools.try_get(rotxn, &amm_pair)?.ok_or_else(|| {
         Error::MissingPoolState {
             asset0: amm_pair.asset0(),
             asset1: amm_pair.asset1(),
@@ -503,6 +504,34 @@ pub(in crate::state) fn apply_swap(
     if amount_receive != amount_receive_after_fee {
         return Err(Error::InvalidSwap);
     }
+    Ok((amm_pair, new_amm_pool_state))
+}
+
+/** Validate an AMM swap against the current pool state.
+ *  This is NOT part of block validation: swaps in a block are applied
+ *  sequentially, so a swap that is stale with respect to the current pool
+ *  state may still be valid later within a block. `apply_swap` performs the
+ *  same check against the pool state at the point at which it is applied. */
+pub(in crate::state) fn validate_swap(
+    pools: &RoPoolsDb,
+    rotxn: &RoTxn,
+    filled_tx: &FilledTransaction,
+) -> Result<(), Error> {
+    let amm_swap = filled_tx.amm_swap().ok_or(Error::InvalidSwap)?;
+    let (_amm_pair, _new_amm_pool_state) =
+        swap_pool_state(pools, rotxn, amm_swap)?;
+    Ok(())
+}
+
+// Apply AMM swap
+pub(in crate::state) fn apply_swap(
+    pools: &PoolsDb,
+    rwtxn: &mut RwTxn,
+    filled_tx: &FilledTransaction,
+) -> Result<(), Error> {
+    let amm_swap = filled_tx.amm_swap().ok_or(Error::InvalidSwap)?;
+    let (amm_pair, new_amm_pool_state) =
+        swap_pool_state(pools, rwtxn, amm_swap)?;
     pools.put(rwtxn, &amm_pair, &new_amm_pool_state)?;
     Ok(())
 }
@@ -535,172 +564,79 @@ pub(in crate::state) fn revert_swap(
 mod test {
     use crate::{
         state::{
-            amm::{AmmPair, PoolState, apply_burn, apply_mint},
+            amm::{AmmPair, PoolState, apply_swap, validate_swap},
+            error::Amm as Error,
             test::fresh_state,
         },
         types::{
             Address, AssetId, BitAssetId, FilledOutput, FilledOutputContent,
-            FilledTransaction, OutPoint, Output, OutputContent, Transaction,
-            TxData, Txid,
+            FilledTransaction, OutPoint, Transaction, TxData, Txid,
         },
     };
 
-    fn bitasset(byte: u8) -> BitAssetId {
-        BitAssetId([byte; blake3::OUT_LEN])
-    }
-
-    fn txid(byte: u8) -> Txid {
-        Txid([byte; blake3::OUT_LEN])
-    }
-
-    fn outpoint(byte: u8, vout: u32) -> OutPoint {
-        OutPoint::Regular {
-            txid: txid(byte),
-            vout,
-        }
-    }
-
-    fn bitasset_output(asset: BitAssetId, value: u64) -> FilledOutput {
-        Output::new(
-            Address::ALL_ZEROS,
-            FilledOutputContent::BitAsset(asset, value),
-        )
-    }
-
-    fn lp_output(
-        asset0: AssetId,
-        asset1: AssetId,
-        amount: u64,
-    ) -> FilledOutput {
-        Output::new(
-            Address::ALL_ZEROS,
-            FilledOutputContent::AmmLpToken {
-                asset0,
-                asset1,
-                amount,
-            },
-        )
-    }
-
+    /** A swap that is stale with respect to the current pool state must be
+     *  rejected. Otherwise it is never evicted from the mempool, and is
+     *  included in block templates that `apply_swap` rejects when the block
+     *  is connected, stalling block production. */
     #[test]
-    fn apply_mint_burn_wrong_lp_baseline() -> anyhow::Result<()> {
-        let (_temp_dir, env, state) =
-            fresh_state("apply_mint_burn_wrong_lp_baseline")?;
-
-        let asset_a = bitasset(1);
-        let asset_b = bitasset(2);
-        let asset0 = AssetId::BitAsset(asset_a);
-        let asset1 = AssetId::BitAsset(asset_b);
-        let pair = AmmPair::new(asset0, asset1);
-
-        let initial_pool = PoolState {
+    fn validate_swap_rejects_stale_swap() -> anyhow::Result<()> {
+        let (env, state) = fresh_state("amm_stale_swap")?;
+        let bitasset0 = BitAssetId([0; 32]);
+        let asset_spend = AssetId::BitAsset(bitasset0);
+        let asset_receive = AssetId::BitAsset(BitAssetId([1; 32]));
+        let amm_pair = AmmPair::new(asset_spend, asset_receive);
+        let pool_state = PoolState {
             reserve0: 1_000_000,
             reserve1: 1_000_000,
             outstanding_lp_tokens: 1_000_000,
-            creation_txid: txid(9),
+            creation_txid: Txid([2; 32]),
         };
         {
             let mut rwtxn = env.write_txn()?;
-            state.amm_pools.put(&mut rwtxn, &pair, &initial_pool)?;
+            state.amm_pools.put(&mut rwtxn, &amm_pair, &pool_state)?;
             rwtxn.commit()?;
         }
-
-        let correct_after_mint = initial_pool.mint(2, 2)?;
-        let actual_lp_tokens_for_deposit = correct_after_mint
-            .outstanding_lp_tokens
-            - initial_pool.outstanding_lp_tokens;
-        anyhow::ensure!(actual_lp_tokens_for_deposit == 2);
-
-        let mint_tx =
-            |lp_token_mint: u64| -> anyhow::Result<FilledTransaction> {
-                let res = FilledTransaction {
-                    transaction: Transaction {
-                        inputs: vec![outpoint(10, 0), outpoint(11, 0)],
-                        outputs: vec![Output::new(
-                            Address::ALL_ZEROS,
-                            OutputContent::AmmLpToken(lp_token_mint),
-                        )],
-                        memo: Vec::new(),
-                        data: Some(TxData::AmmMint {
-                            amount0: 2,
-                            amount1: 2,
-                            lp_token_mint,
-                        }),
-                    },
-                    spent_utxos: vec![
-                        bitasset_output(asset_a, 2),
-                        bitasset_output(asset_b, 2),
-                    ],
-                };
-                let filled_mint_outputs = res
-                    .filled_outputs()
-                    .ok_or_else(|| anyhow::anyhow!("AMM LP output fills"))?;
-                anyhow::ensure!(
-                    filled_mint_outputs[0].content()
-                        == &FilledOutputContent::AmmLpToken {
-                            asset0,
-                            asset1,
-                            amount: lp_token_mint,
-                        }
-                );
-                Ok(res)
-            };
-
-        // Attempting to apply a mint with incorrect declared lp_tokens should
-        // fail
-        {
-            let attacker_declared_lp = 500_001;
-            let mint_tx = mint_tx(attacker_declared_lp)?;
-            let mut rwtxn = env.write_txn()?;
-            anyhow::ensure!(
-                apply_mint(&state.amm_pools, &mut rwtxn, &mint_tx).is_err()
-            );
-        }
-        // Attempting to apply a mint with correctly declared lp_tokens should
-        // succeed
-        {
-            let mint_tx = mint_tx(actual_lp_tokens_for_deposit)?;
-            let mut rwtxn = env.write_txn()?;
-            let () = apply_mint(&state.amm_pools, &mut rwtxn, &mint_tx)?;
-            rwtxn.commit()?;
-        }
-
-        let lp_token_burn = 500_001;
-        let burn_tx = FilledTransaction {
-            transaction: Transaction {
-                inputs: vec![outpoint(12, 0)],
-                outputs: vec![
-                    Output::new(
-                        Address::ALL_ZEROS,
-                        OutputContent::BitAsset(500_001),
-                    ),
-                    Output::new(
-                        Address::ALL_ZEROS,
-                        OutputContent::BitAsset(500_001),
-                    ),
-                ],
-                memo: Vec::new(),
-                data: Some(TxData::AmmBurn {
-                    amount0: 500_001,
-                    amount1: 500_001,
-                    lp_token_burn,
-                }),
-            },
-            spent_utxos: vec![lp_output(asset0, asset1, lp_token_burn)],
+        // A swap declaring the amount to receive that the pool state above
+        // pays out.
+        let amount_spend = 1_000;
+        let amount_receive = pool_state.reserve1
+            - pool_state.swap_asset0_for_asset1(amount_spend)?.reserve1;
+        let mut transaction = Transaction::new(
+            vec![OutPoint::Regular {
+                txid: Txid([3; 32]),
+                vout: 0,
+            }],
+            Vec::new(),
+        );
+        transaction.data = Some(TxData::AmmSwap {
+            amount_spent: amount_spend,
+            amount_receive,
+            pair_asset: asset_receive,
+        });
+        let filled_tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![FilledOutput::new(
+                Address([0; 20]),
+                FilledOutputContent::BitAsset(bitasset0, amount_spend),
+            )],
         };
-
         {
-            let mut rwtxn = env.write_txn()?;
-            let () = apply_burn(&state.amm_pools, &mut rwtxn, &burn_tx)?;
-            rwtxn.commit()?;
-        }
-        let pool_after_burn = {
             let rotxn = env.read_txn()?;
-            state.amm_pools.get(&rotxn, &pair)?
-        };
-        assert_eq!(pool_after_burn.reserve0, 500_001);
-        assert_eq!(pool_after_burn.reserve1, 500_001);
-        assert_eq!(pool_after_burn.outstanding_lp_tokens, 500_001);
+            validate_swap(&state.amm_pools, &rotxn, &filled_tx)?;
+        }
+        // Applying the swap moves the pool, so the same swap is now stale.
+        {
+            let mut rwtxn = env.write_txn()?;
+            apply_swap(&state.amm_pools, &mut rwtxn, &filled_tx)?;
+            rwtxn.commit()?;
+        }
+        let rotxn = env.read_txn()?;
+        let err = validate_swap(&state.amm_pools, &rotxn, &filled_tx)
+            .expect_err("a stale swap must be rejected");
+        anyhow::ensure!(
+            matches!(err, Error::InvalidSwap),
+            "unexpected error: {err:?}"
+        );
         Ok(())
     }
 }

--- a/lib/state/dutch_auction.rs
+++ b/lib/state/dutch_auction.rs
@@ -108,12 +108,21 @@ impl DutchAuctionState {
         if price == 0 {
             do yeet error::Bid::InvalidPrice
         };
-        // Calculate order quantity for this bid, in terms of the base
+        // `price` is the quote amount for the whole remaining base amount, so
+        // a larger bid asks for more base than the auction still offers.
+        // This also keeps `price - bid_amount` below from underflowing.
+        if bid_amount > price {
+            do yeet error::Bid::QuantityTooLarge
+        };
+        // Calculate order quantity for this bid, in terms of the base.
+        // Rounding must be down: rounding up would hand a bid too small to
+        // buy a whole base unit at the current price a full unit anyway,
+        // draining the auction's inventory for less than it is priced at.
         let order_quantity: u128 = {
             /* bid_amount / (price / base_amount_remaining)
              * == (bid_amount * base_amount_remaining) / price */
             (bid_amount as u128 * base_amount_remaining.latest().data as u128)
-                .div_ceil(price as u128)
+                / (price as u128)
         };
         let order_quantity: u64 =
             if order_quantity <= base_amount_remaining.latest().data as u128 {
@@ -483,11 +492,59 @@ mod test {
     }
 
     #[test]
-    fn bid_on_sold_out_auction_fails() -> anyhow::Result<()> {
-        let sold_out = test_auction().bid(Txid::default(), 501, 1)?;
-        anyhow::ensure!(sold_out.base_amount_remaining.latest().data == 0);
-        anyhow::ensure!(sold_out.price_after_most_recent_bid.latest().data > 0);
-        anyhow::ensure!(sold_out.bid(Txid::default(), 1, 2).is_err());
-        Ok(())
+    fn sold_out_auction_rejects_further_bids() {
+        let txid = Txid([0; 32]);
+        let auction = make_auction(2);
+        // First bid legitimately sells the auction out. At height 1 the price
+        // for the remaining 2 base is 900, and selling out requires paying it
+        // in full, which leaves no price remaining.
+        let sold_out =
+            auction.bid(txid, 900, 1).expect("first bid should succeed");
+        assert_eq!(sold_out.base_amount_remaining.latest().data, 0);
+        assert_eq!(sold_out.price_after_most_recent_bid.latest().data, 0);
+        // A further bid on the sold-out auction must be rejected cleanly,
+        // rather than panicking on the next-end-price division.
+        assert!(matches!(
+            sold_out.bid(txid, 1, 2),
+            Err(error::Bid::AuctionExhausted)
+        ));
+    }
+
+    /// A bid too small to buy a whole base unit at the current price must
+    /// receive nothing, rather than being rounded up to a full unit.
+    #[test]
+    fn dust_bid_receives_no_base() {
+        let txid = Txid([0; 32]);
+        let auction = make_auction(2);
+        // The remaining 2 base are priced at 1000, so 1 quote unit buys
+        // `2/1000` of a base unit, i.e. nothing.
+        let after_bid = auction.bid(txid, 1, 0).expect("bid should succeed");
+        assert_eq!(after_bid.base_amount_remaining.latest().data, 2);
+        assert_eq!(after_bid.quote_amount.latest().data, 1);
+    }
+
+    /// Repeated dust bids must not drain the auction's inventory for less
+    /// quote than the inventory is priced at.
+    #[test]
+    fn dust_bids_cannot_drain_inventory() {
+        let txid = Txid([0; 32]);
+        let base_amount = 2;
+        let mut auction = make_auction(base_amount);
+        for _ in 0..100 {
+            auction = auction.bid(txid, 1, 0).expect("bid should succeed");
+        }
+        // 100 quote units is far below the 1000 that the 2 base are priced
+        // at, so none of them may have been sold.
+        assert_eq!(auction.base_amount_remaining.latest().data, base_amount);
+        assert_eq!(auction.quote_amount.latest().data, 100);
+        // Selling out at all requires paying the full remaining price.
+        let price = auction.price_after_most_recent_bid.latest().data;
+        assert!(matches!(
+            auction.bid(txid, price + 1, 0),
+            Err(error::Bid::QuantityTooLarge)
+        ));
+        let sold_out = auction.bid(txid, price, 0).expect("bid should succeed");
+        assert_eq!(sold_out.base_amount_remaining.latest().data, 0);
+        assert_eq!(sold_out.quote_amount.latest().data, 100 + price);
     }
 }

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -404,6 +404,10 @@ impl State {
      *        of BitAsset control coin inputs
      *      * The number of BitAsset outputs is at least
      *        the number of unique BitAssets in the inputs.
+     *      * If there are no unique BitAssets in the inputs, then there must
+     *        be no BitAsset outputs, unless the tx is an AMM burn or a Dutch
+     *        auction collect, which pay out BitAssets held by the AMM pool or
+     *        Dutch auction.
      *  * If the tx is a BitAsset update, then there must be at least one
      *    BitAsset control coin input and output.
      *  * If the tx is an AMM Burn, then
@@ -453,8 +457,15 @@ impl State {
         let n_bitasset_control_inputs: usize =
             tx.spent_bitasset_controls().count();
         let n_bitasset_outputs: usize = tx.bitasset_outputs().count();
-        let n_unique_bitasset_outputs: usize =
-            tx.unique_spent_bitassets().len();
+        /* Only the AMM and Dutch auction checks below use the number of
+         * unique BitAsset outputs, so it is not computed for regular txs.
+         * If the outputs cannot be filled then the tx is invalid,
+         * so those checks must reject it. */
+        let n_unique_bitasset_outputs: usize = if tx.is_regular() {
+            0
+        } else {
+            tx.n_unique_bitasset_outputs().unwrap_or_default()
+        };
         let n_bitasset_control_outputs: usize =
             tx.bitasset_control_outputs().count();
         if tx.is_update()
@@ -593,7 +604,16 @@ impl State {
                     n_bitasset_outputs,
                 });
             }
-            if n_unique_bitasset_inputs == 0 && n_bitasset_outputs != 0 {
+            /* AMM burns and Dutch auction collects pay out BitAssets that are
+             * held by the AMM pool/Dutch auction, rather than by the inputs,
+             * so they may have BitAsset outputs without any BitAsset inputs.
+             * The BitAsset outputs of such txs are constrained by the checks
+             * above, and their values are checked against the pool/auction
+             * state when the tx is applied. */
+            if n_unique_bitasset_inputs == 0
+                && n_bitasset_outputs != 0
+                && !(tx.is_amm_burn() || tx.is_dutch_auction_collect())
+            {
                 return Err(Error::UnbalancedBitAssets {
                     n_unique_bitasset_inputs,
                     n_bitasset_outputs,
@@ -804,10 +824,11 @@ mod test {
         authorization,
         state::{Error, State, error},
         types::{
-            Address, AuthorizedTransaction, BitAssetData, BitAssetId,
-            FilledOutput, FilledOutputContent, FilledTransaction, Hash,
-            InPoint, OutPoint, OutPointKey, Output, OutputContent, SpentOutput,
-            Transaction, TxData, Txid, VerifyingKey, WithdrawalOutputContent,
+            Address, AssetId, AuthorizedTransaction, BitAssetData, BitAssetId,
+            DutchAuctionId, FilledOutput, FilledOutputContent,
+            FilledTransaction, Hash, InPoint, OutPoint, OutPointKey, Output,
+            OutputContent, SpentOutput, Transaction, TxData, Txid,
+            VerifyingKey,
         },
     };
 
@@ -1007,6 +1028,147 @@ mod test {
         );
         state.validate_bitassets(&rotxn, &tx).expect(
             "registration burning the matching reservation should validate",
+        );
+        Ok(())
+    }
+
+    /// An AMM burn spends LP tokens and pays out the underlying BitAssets, so
+    /// it has no BitAsset inputs. Counting the spent BitAssets as the unique
+    /// BitAsset outputs would reject every such burn.
+    #[test]
+    fn validate_bitassets_accepts_amm_burn() -> anyhow::Result<()> {
+        let (env, state) = fresh_state("amm-burn")?;
+        let rotxn = env.read_txn()?;
+        let address = Address([0; 20]);
+        let asset0 = AssetId::BitAsset(BitAssetId([1; 32]));
+        let asset1 = AssetId::BitAsset(BitAssetId([2; 32]));
+        let (amount0, amount1, lp_token_burn) = (10, 20, 5);
+        let mut transaction = Transaction::new(
+            vec![OutPoint::Regular {
+                txid: Txid([0; 32]),
+                vout: 0,
+            }],
+            vec![
+                Output::new(address, OutputContent::BitAsset(amount0)),
+                Output::new(address, OutputContent::BitAsset(amount1)),
+            ],
+        );
+        transaction.data = Some(TxData::AmmBurn {
+            amount0,
+            amount1,
+            lp_token_burn,
+        });
+        let lp_token = FilledOutput::new(
+            address,
+            FilledOutputContent::AmmLpToken {
+                asset0,
+                asset1,
+                amount: lp_token_burn,
+            },
+        );
+        let tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![lp_token],
+        };
+        state
+            .validate_bitassets(&rotxn, &tx)
+            .expect("an AMM burn paying out both BitAssets should validate");
+        Ok(())
+    }
+
+    /// An AMM mint spends both BitAssets of the pair, and returns the
+    /// remainder as change, so the number of unique BitAsset outputs must
+    /// match the number of unique BitAsset inputs.
+    #[test]
+    fn validate_bitassets_accepts_amm_mint() -> anyhow::Result<()> {
+        let (env, state) = fresh_state("amm-mint")?;
+        let rotxn = env.read_txn()?;
+        let address = Address([0; 20]);
+        let bitasset0 = BitAssetId([1; 32]);
+        let bitasset1 = BitAssetId([2; 32]);
+        let (amount0, amount1, lp_token_mint) = (50, 50, 10);
+        let mut transaction = Transaction::new(
+            vec![
+                OutPoint::Regular {
+                    txid: Txid([0; 32]),
+                    vout: 0,
+                },
+                OutPoint::Regular {
+                    txid: Txid([0; 32]),
+                    vout: 1,
+                },
+            ],
+            vec![
+                Output::new(address, OutputContent::BitAsset(amount0)),
+                Output::new(address, OutputContent::BitAsset(amount1)),
+                Output::new(address, OutputContent::AmmLpToken(lp_token_mint)),
+            ],
+        );
+        transaction.data = Some(TxData::AmmMint {
+            amount0,
+            amount1,
+            lp_token_mint,
+        });
+        let tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![
+                FilledOutput::new(
+                    address,
+                    FilledOutputContent::BitAsset(bitasset0, 2 * amount0),
+                ),
+                FilledOutput::new(
+                    address,
+                    FilledOutputContent::BitAsset(bitasset1, 2 * amount1),
+                ),
+            ],
+        };
+        state.validate_bitassets(&rotxn, &tx).expect(
+            "an AMM mint returning both BitAssets as change should validate",
+        );
+        Ok(())
+    }
+
+    /// A Dutch auction collect spends an auction receipt and pays out the
+    /// offered and received assets, so it has no BitAsset inputs.
+    #[test]
+    fn validate_bitassets_accepts_dutch_auction_collect() -> anyhow::Result<()>
+    {
+        let (env, state) = fresh_state("dutch-auction-collect")?;
+        let rotxn = env.read_txn()?;
+        let address = Address([0; 20]);
+        let asset_offered = AssetId::BitAsset(BitAssetId([1; 32]));
+        let asset_receive = AssetId::BitAsset(BitAssetId([2; 32]));
+        let (amount_offered_remaining, amount_received) = (10, 20);
+        let mut transaction = Transaction::new(
+            vec![OutPoint::Regular {
+                txid: Txid([0; 32]),
+                vout: 0,
+            }],
+            vec![
+                Output::new(
+                    address,
+                    OutputContent::BitAsset(amount_offered_remaining),
+                ),
+                Output::new(address, OutputContent::BitAsset(amount_received)),
+            ],
+        );
+        transaction.data = Some(TxData::DutchAuctionCollect {
+            asset_offered,
+            asset_receive,
+            amount_offered_remaining,
+            amount_received,
+        });
+        let auction_id = DutchAuctionId(Txid([0; 32]));
+        let auction_receipt = FilledOutput::new(
+            address,
+            FilledOutputContent::DutchAuctionReceipt(auction_id),
+        );
+        let tx = FilledTransaction {
+            transaction,
+            spent_utxos: vec![auction_receipt],
+        };
+        state.validate_bitassets(&rotxn, &tx).expect(
+            "a Dutch auction collect paying out both assets should validate",
         );
         Ok(())
     }

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -664,6 +664,19 @@ impl State {
             .map_err(Error::Authorization)?;
         let fee =
             self.validate_filled_transaction(rotxn, &filled_transaction)?;
+        /* An AMM swap declares the amount to receive, which is only checked
+         * against the pool state when the tx is applied. That check cannot be
+         * part of block validation, since swaps in a block are applied
+         * sequentially, but a swap that is stale with respect to the current
+         * pool state can never be applied at the front of a block, so it must
+         * not be accepted into the mempool. */
+        if filled_transaction.is_amm_swap() {
+            let () = amm::validate_swap(
+                &self.amm_pools,
+                rotxn,
+                &filled_transaction,
+            )?;
+        }
         Ok(fee)
     }
 

--- a/lib/types/transaction/mod.rs
+++ b/lib/types/transaction/mod.rs
@@ -1076,6 +1076,19 @@ impl FilledTransaction {
             .collect()
     }
 
+    /** Return the number of unique BitAssets occurring in the outputs.
+     *  Returns `None` if the outputs cannot be filled because the tx is
+     *  invalid. */
+    pub fn n_unique_bitasset_outputs(&self) -> Option<usize> {
+        let res = self
+            .filled_outputs()?
+            .iter()
+            .filter_map(FilledOutput::bitasset)
+            .unique()
+            .count();
+        Some(res)
+    }
+
     /** Return a vector of pairs consisting of an [`AssetId`] and the combined
      *  input value for that asset.
      *  The vector is ordered such that assets occur in the same order


### PR DESCRIPTION
**What's wrong**

`MemPool::get_unconfirmed_utxos` (`lib/mempool.rs`) collects every output of every mempool transaction that pays the requested address, without consulting the mempool's own `spent_utxos` index. When one mempool transaction spends another's unconfirmed output, that output is still reported as a UTXO. The result reaches users through `Node::get_unconfirmed_utxos_by_addresses`, the `my_unconfirmed_utxos` RPC, and the wallet's unconfirmed UTXO set, so unconfirmed balances are overstated, and a caller that treats the result as spendable can build a transaction that `MemPool::put` then rejects with `UtxoDoubleSpent`.

**The fix**

Replaces the final `collect()` with a `try_fold` that looks each outpoint up in `self.spent_utxos`, in the same read transaction, and drops those already spent by another mempool transaction.

No regression test in this patch; happy to add one if you'd like it covered.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260703-1444-openclaw-confirm-kimiclaw-plain-bitassets-mempool-unconfirmed-utxo-spent-blindness

---
Part of a short series for this repo (fix 4 of 4); builds on https://github.com/LayerTwo-Labs/plain-bitassets/pull/55, so it reads best merged after that one. Happy to rebase or split if you'd prefer them independent.