### PR TITLE
Utreexo, State Commitments, and Lite Wallet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5490,6 +5490,7 @@ dependencies = [
  "rayon",
  "rcgen",
  "rustls",
+ "rustreexo",
  "semver",
  "serde",
  "serde_json",
@@ -6560,6 +6561,14 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rustreexo"
+version = "0.3.0"
+source = "git+https://github.com/mit-dci/rustreexo?rev=6da503b598470f6e87aa9d769b94df64df7ff3ae#6da503b598470f6e87aa9d769b94df64df7ff3ae"
+dependencies = [
+ "bitcoin_hashes",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ rev = "1100b6085d9ed64eeaf1b57b3c44609626bd4b23"
 git = "https://github.com/Ash-L2L/l2l-openapi"
 rev = "5f8fb2237c95725731d5fb10542098303d82e215"
 
+[workspace.dependencies.rustreexo]
+git = "https://github.com/mit-dci/rustreexo"
+rev = "6da503b598470f6e87aa9d769b94df64df7ff3ae"
+
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 assertions_on_result_states = "allow"

--- a/app/app.rs
+++ b/app/app.rs
@@ -61,7 +61,7 @@ fn update_wallet(node: &Node, wallet: &Wallet) -> Result<(), Error> {
     let addresses = wallet.get_addresses()?;
     let unconfirmed_utxos =
         node.get_unconfirmed_utxos_by_addresses(&addresses)?;
-    let utxos = node.get_utxos_by_addresses(&addresses)?;
+    let utxos = node.get_utxos_by_addresses(&addresses, 0)?;
     let confirmed_outpoints: Vec<_> = wallet.get_utxos()?.into_keys().collect();
     let confirmed_spent = node
         .get_spent_utxos(&confirmed_outpoints)?

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -65,6 +65,7 @@ transitive = { workspace = true }
 utoipa = { workspace = true, features = ["macros", "non_strict_integers"] }
 x25519-dalek = { workspace = true, features = ["serde", "static_secrets"] }
 zeromq = { workspace = true, optional = true }
+rustreexo = { workspace = true }
 
 [dependencies.libes]
 workspace = true

--- a/lib/archive.rs
+++ b/lib/archive.rs
@@ -7,6 +7,7 @@ use std::{
 use bitcoin::{self, hashes::Hash as _};
 use fallible_iterator::{FallibleIterator, IteratorExt};
 use heed::types::SerdeBincode;
+use serde::{Deserialize, Serialize};
 use sneed::{
     DatabaseUnique, EnvError, RoTxn, RwTxn, RwTxnError, UnitKey,
     db::{self, error::Error as DbError},
@@ -14,7 +15,8 @@ use sneed::{
 };
 
 use crate::types::{
-    Block, BlockHash, BmmResult, Body, Header, Tip, Txid, VERSION, Version,
+    Address, AddressTxidKey, Block, BlockHash, BmmResult, Body,
+    FilledTransaction, Header, MerkleProof, Tip, Txid, VERSION, Version,
     proto::mainchain,
 };
 
@@ -76,6 +78,17 @@ pub enum Error {
     NoMainHeight(bitcoin::BlockHash),
     #[error("no tx with txid {0}")]
     NoTx(Txid),
+    #[error("filled transaction length mismatch: {expected} / {actual}")]
+    TxDbFilledTxLenMismatch { expected: usize, actual: usize },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FilledTxEntry {
+    pub tx: FilledTransaction,
+    pub merkle_proof: MerkleProof,
+    pub block_hash: BlockHash,
+    pub block_height: u32,
+    pub unix_stamp: u64,
 }
 
 #[derive(Clone)]
@@ -151,11 +164,13 @@ pub struct Archive {
         SerdeBincode<Txid>,
         SerdeBincode<BTreeMap<BlockHash, u32>>,
     >,
+    /// Capped tx cache, keyed by (address, txid).
+    txdb: DatabaseUnique<AddressTxidKey, SerdeBincode<FilledTxEntry>>,
     _version: DatabaseUnique<UnitKey, SerdeBincode<Version>>,
 }
 
 impl Archive {
-    pub const NUM_DBS: u32 = 14;
+    pub const NUM_DBS: u32 = 15;
 
     pub fn new(env: &sneed::Env) -> Result<Self, Error> {
         let mut rwtxn = env.write_txn()?;
@@ -227,6 +242,7 @@ impl Archive {
         let total_work = DatabaseUnique::create(env, &mut rwtxn, "total_work")?;
         let txid_to_inclusions =
             DatabaseUnique::create(env, &mut rwtxn, "txid_to_inclusions")?;
+        let txdb = DatabaseUnique::create(env, &mut rwtxn, "txdb")?;
         rwtxn.commit()?;
         Ok(Self {
             block_hash_to_height,
@@ -242,6 +258,7 @@ impl Archive {
             successors,
             total_work,
             txid_to_inclusions,
+            txdb,
             _version: version,
         })
     }
@@ -1459,6 +1476,125 @@ impl Archive {
                 }
             }
         }
+    }
+
+    pub fn prune_txdb_block(
+        &self,
+        rwtxn: &mut RwTxn,
+        block_hash: BlockHash,
+    ) -> Result<usize, Error> {
+        let keys = {
+            let mut keys = Vec::new();
+            let mut iter = self.txdb.iter(rwtxn).map_err(DbError::from)?;
+            while let Some((key, entry)) = iter.next().map_err(DbError::from)? {
+                if entry.block_hash == block_hash {
+                    keys.push(key);
+                }
+            }
+            keys
+        };
+        for key in &keys {
+            let _ = self.txdb.delete(rwtxn, key)?;
+        }
+        Ok(keys.len())
+    }
+
+    pub fn prune_txdb_older_than(
+        &self,
+        rwtxn: &mut RwTxn,
+        cutoff_unix: u64,
+    ) -> Result<usize, Error> {
+        let keys = {
+            let mut keys = Vec::new();
+            let mut iter = self.txdb.iter(rwtxn).map_err(DbError::from)?;
+            while let Some((key, entry)) = iter.next().map_err(DbError::from)? {
+                if entry.unix_stamp < cutoff_unix {
+                    keys.push(key);
+                }
+            }
+            keys
+        };
+        for key in &keys {
+            let _ = self.txdb.delete(rwtxn, key)?;
+        }
+        Ok(keys.len())
+    }
+
+    pub fn put_txdb_for_connected_block(
+        &self,
+        rwtxn: &mut RwTxn,
+        block_hash: BlockHash,
+        block_height: u32,
+        body: &Body,
+        filled_txs: &[FilledTransaction],
+        unix_stamp: u64,
+    ) -> Result<(), Error> {
+        if body.transactions.len() != filled_txs.len() {
+            return Err(Error::TxDbFilledTxLenMismatch {
+                expected: body.transactions.len(),
+                actual: filled_txs.len(),
+            });
+        }
+        for (tx_index, filled_tx) in filled_txs.iter().enumerate() {
+            let txid = filled_tx.txid();
+            debug_assert_eq!(body.transactions[tx_index].txid(), txid);
+            let merkle_proof = Body::compute_tx_merkle_proof(
+                &body.coinbase,
+                &body.transactions,
+                tx_index,
+            );
+            debug_assert_eq!(merkle_proof.leaf_index, tx_index + 1);
+
+            let mut addresses = HashSet::new();
+            addresses.extend(
+                filled_tx.spent_utxos.iter().map(|output| output.address),
+            );
+            addresses.extend(
+                filled_tx
+                    .transaction
+                    .outputs
+                    .iter()
+                    .map(|output| output.address),
+            );
+
+            for address in addresses {
+                let key = AddressTxidKey::new(address, txid);
+                let entry = FilledTxEntry {
+                    tx: filled_tx.clone(),
+                    merkle_proof: merkle_proof.clone(),
+                    block_hash,
+                    block_height,
+                    unix_stamp,
+                };
+                self.txdb.put(rwtxn, &key, &entry)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn get_txdb_entries_by_address(
+        &self,
+        rotxn: &RoTxn,
+        addresses: &HashSet<Address>,
+        height_threshold: u32,
+    ) -> Result<Vec<FilledTxEntry>, Error> {
+        let mut entries = Vec::new();
+        for address in addresses {
+            let start = AddressTxidKey::start(*address);
+            let end = AddressTxidKey::end(*address);
+            let mut iter = self
+                .txdb
+                .range(rotxn, &(start..=end))
+                .map_err(DbError::from)?;
+            while let Some((_key, entry)) =
+                iter.next().map_err(DbError::from)?
+            {
+                if entry.block_height >= height_threshold {
+                    entries.push(entry);
+                }
+            }
+        }
+        Ok(entries)
     }
 }
 

--- a/lib/archive.rs
+++ b/lib/archive.rs
@@ -6,7 +6,7 @@ use std::{
 
 use bitcoin::{self, hashes::Hash as _};
 use fallible_iterator::{FallibleIterator, IteratorExt};
-use heed::types::SerdeBincode;
+use heed::types::{Bytes, SerdeBincode};
 use serde::{Deserialize, Serialize};
 use sneed::{
     DatabaseUnique, EnvError, RoTxn, RwTxn, RwTxnError, UnitKey,
@@ -15,10 +15,20 @@ use sneed::{
 };
 
 use crate::types::{
-    Address, AddressTxidKey, Block, BlockHash, BmmResult, Body,
-    FilledTransaction, Header, MerkleProof, Tip, Txid, VERSION, Version,
-    proto::mainchain,
+    Accumulator, AccumulatorDiff, Address, AddressTxidKey, Block, BlockHash,
+    BmmResult, Body, FilledTransaction, Header, MerkleProof, Tip, Txid,
+    VERSION, Version, proto::mainchain,
 };
+
+/// Check for accumulator history eligible for pruning once per week.
+pub const ACCUMULATOR_PRUNE_INTERVAL_BLOCKS: u32 = 144 * 7;
+
+/// Maximum number of sidechain blocks that may be disconnected in one reorg.
+/// Snapshots and diffs required to reconstruct this window are retained.
+pub const ACCUMULATOR_REORG_HORIZON_BLOCKS: u32 = 144 * 7 * 4 * 6;
+
+/// Persist one full accumulator snapshot per week.
+pub const ACCUMULATOR_SNAPSHOT_INTERVAL_BLOCKS: u32 = 144 * 7;
 
 #[allow(clippy::duplicated_attributes)]
 #[derive(Debug, thiserror::Error, transitive::Transitive)]
@@ -80,6 +90,10 @@ pub enum Error {
     NoTx(Txid),
     #[error("filled transaction length mismatch: {expected} / {actual}")]
     TxDbFilledTxLenMismatch { expected: usize, actual: usize },
+    #[error("no accumulator diff for block {0}")]
+    NoAccumulatorDiff(BlockHash),
+    #[error("Utreexo error: {0}")]
+    Utreexo(String),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -166,11 +180,15 @@ pub struct Archive {
     >,
     /// Capped tx cache, keyed by (address, txid).
     txdb: DatabaseUnique<AddressTxidKey, SerdeBincode<FilledTxEntry>>,
+    accumulators: DatabaseUnique<SerdeBincode<BlockHash>, Bytes>,
+    accumulator_diffs:
+        DatabaseUnique<SerdeBincode<BlockHash>, SerdeBincode<AccumulatorDiff>>,
+    accumulator_reorg_floor: DatabaseUnique<UnitKey, SerdeBincode<u32>>,
     _version: DatabaseUnique<UnitKey, SerdeBincode<Version>>,
 }
 
 impl Archive {
-    pub const NUM_DBS: u32 = 15;
+    pub const NUM_DBS: u32 = 18;
 
     pub fn new(env: &sneed::Env) -> Result<Self, Error> {
         let mut rwtxn = env.write_txn()?;
@@ -242,6 +260,13 @@ impl Archive {
         let total_work = DatabaseUnique::create(env, &mut rwtxn, "total_work")?;
         let txid_to_inclusions =
             DatabaseUnique::create(env, &mut rwtxn, "txid_to_inclusions")?;
+        let accumulators =
+            DatabaseUnique::create(env, &mut rwtxn, "accumulators")
+                .map_err(EnvError::from)?;
+        let accumulator_diffs =
+            DatabaseUnique::create(env, &mut rwtxn, "accumulator_diffs")?;
+        let accumulator_reorg_floor =
+            DatabaseUnique::create(env, &mut rwtxn, "accumulator_reorg_floor")?;
         let txdb = DatabaseUnique::create(env, &mut rwtxn, "txdb")?;
         rwtxn.commit()?;
         Ok(Self {
@@ -259,6 +284,9 @@ impl Archive {
             total_work,
             txid_to_inclusions,
             txdb,
+            accumulators,
+            accumulator_diffs,
+            accumulator_reorg_floor,
             _version: version,
         })
     }
@@ -1596,6 +1624,149 @@ impl Archive {
         }
         Ok(entries)
     }
+
+    /// Store an accumulator snapshot for a specific block.
+    pub fn put_accumulator(
+        &self,
+        rwtxn: &mut RwTxn,
+        block_hash: BlockHash,
+        block_height: u32,
+        accumulator: &Accumulator,
+    ) -> Result<(), Error> {
+        let mut snapshot = Vec::new();
+        snapshot.extend_from_slice(&block_height.to_le_bytes());
+        accumulator
+            .serialize_into(&mut snapshot)
+            .map_err(Error::Utreexo)?;
+        self.accumulators
+            .put(rwtxn, &block_hash, &snapshot)
+            .map_err(DbError::from)?;
+        Ok(())
+    }
+
+    fn decode_accumulator_snapshot_height(bytes: &[u8]) -> Result<u32, Error> {
+        let height_bytes = bytes.first_chunk::<4>().ok_or_else(|| {
+            Error::Utreexo(
+                "accumulator snapshot is shorter than its height prefix"
+                    .to_owned(),
+            )
+        })?;
+        Ok(u32::from_le_bytes(*height_bytes))
+    }
+
+    /// Oldest sidechain height for which retained accumulator history is
+    /// guaranteed to support reconstruction.
+    pub fn accumulator_reorg_floor(&self, rotxn: &RoTxn) -> Result<u32, Error> {
+        self.accumulator_reorg_floor
+            .try_get(rotxn, &())
+            .map(|floor| floor.unwrap_or_default())
+            .map_err(|err| DbError::from(err).into())
+    }
+
+    /// Move the stored reorg floor forward, never backward.
+    pub fn advance_accumulator_reorg_floor(
+        &self,
+        rwtxn: &mut RwTxn,
+        new_floor: u32,
+    ) -> Result<(), Error> {
+        let current_floor = self.accumulator_reorg_floor(rwtxn)?;
+        if new_floor > current_floor {
+            self.accumulator_reorg_floor
+                .put(rwtxn, &(), &new_floor)
+                .map_err(DbError::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn prune_accumulator_older_than(
+        &self,
+        rwtxn: &mut RwTxn,
+        threshold_block_height: u32,
+    ) -> Result<(), Error> {
+        let keys = {
+            let mut keys = Vec::new();
+            let mut iter =
+                self.accumulators.iter(rwtxn).map_err(DbError::from)?;
+
+            while let Some((block_hash, snapshot_bytes)) =
+                iter.next().map_err(DbError::from)?
+            {
+                let snapshot_height =
+                    Self::decode_accumulator_snapshot_height(snapshot_bytes)?;
+                if snapshot_height < threshold_block_height {
+                    keys.push(block_hash);
+                }
+            }
+
+            keys
+        };
+
+        for key in &keys {
+            let _ = self.accumulators.delete(rwtxn, key)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn put_accumulator_diff(
+        &self,
+        rwtxn: &mut RwTxn,
+        block_hash: BlockHash,
+        diff: &AccumulatorDiff,
+    ) -> Result<(), Error> {
+        self.accumulator_diffs
+            .put(rwtxn, &block_hash, diff)
+            .map_err(DbError::from)?;
+        Ok(())
+    }
+
+    pub fn try_get_accumulator_diff(
+        &self,
+        rotxn: &RoTxn,
+        block_hash: BlockHash,
+    ) -> Result<Option<AccumulatorDiff>, Error> {
+        self.accumulator_diffs
+            .try_get(rotxn, &block_hash)
+            .map_err(|err| DbError::from(err).into())
+    }
+
+    pub fn get_accumulator_diff(
+        &self,
+        rotxn: &RoTxn,
+        block_hash: BlockHash,
+    ) -> Result<AccumulatorDiff, Error> {
+        self.try_get_accumulator_diff(rotxn, block_hash)?
+            .ok_or(Error::NoAccumulatorDiff(block_hash))
+    }
+
+    pub fn prune_accumulator_diffs_older_than(
+        &self,
+        rwtxn: &mut RwTxn,
+        threshold_block_height: u32,
+    ) -> Result<(), Error> {
+        let keys = {
+            let mut keys = Vec::new();
+            let mut iter =
+                self.accumulator_diffs.iter(rwtxn).map_err(DbError::from)?;
+
+            while let Some((block_hash, _diff)) =
+                iter.next().map_err(DbError::from)?
+            {
+                let height = self.get_height(rwtxn, block_hash)?;
+                if height < threshold_block_height {
+                    keys.push(block_hash);
+                }
+            }
+
+            keys
+        };
+
+        for key in &keys {
+            let _ = self.accumulator_diffs.delete(rwtxn, key)?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Return a fallible iterator over ancestor headers of a block,
@@ -1732,5 +1903,76 @@ impl FallibleIterator for AncestorsRev<'_, '_> {
         } else {
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_env(
+        test_name: &str,
+    ) -> anyhow::Result<(temp_dir::TempDir, sneed::Env)> {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos();
+        let temp_dir = temp_dir::TempDir::with_prefix(format!(
+            "plain-bitassets-{test_name}-{}-{nanos}",
+            std::process::id()
+        ))?;
+        let mut opts = heed::EnvOpenOptions::new();
+        opts.map_size(64 * 1024 * 1024).max_dbs(Archive::NUM_DBS);
+        let env = unsafe { sneed::Env::open(&opts, temp_dir.path()) }?;
+        Ok((temp_dir, env))
+    }
+
+    #[test]
+    fn accumulator_archive_storage_roundtrips() -> anyhow::Result<()> {
+        let (_temp_dir, env) =
+            temp_env("accumulator_archive_storage_roundtrips")?;
+        let archive = Archive::new(&env)?;
+        let block_hash: BlockHash = [7; 32].into();
+        let block_height = 42;
+
+        let accumulator = Accumulator::default();
+        let mut expected_accumulator_bytes = Vec::new();
+        accumulator
+            .serialize_into(&mut expected_accumulator_bytes)
+            .map_err(anyhow::Error::msg)?;
+
+        let mut diff = AccumulatorDiff::default();
+        diff.insert([1; 32]);
+        diff.remove([2; 32]);
+
+        let mut rwtxn = env.write_txn()?;
+        archive.put_accumulator(
+            &mut rwtxn,
+            block_hash,
+            block_height,
+            &accumulator,
+        )?;
+        archive.put_accumulator_diff(&mut rwtxn, block_hash, &diff)?;
+        archive.advance_accumulator_reorg_floor(&mut rwtxn, 12)?;
+        archive.advance_accumulator_reorg_floor(&mut rwtxn, 7)?;
+        rwtxn.commit()?;
+
+        let rotxn = env.read_txn()?;
+        assert_eq!(archive.get_accumulator_diff(&rotxn, block_hash)?, diff);
+        assert_eq!(archive.accumulator_reorg_floor(&rotxn)?, 12);
+
+        let snapshot = archive.accumulators.get(&rotxn, &block_hash)?;
+        assert_eq!(
+            Archive::decode_accumulator_snapshot_height(snapshot)?,
+            block_height
+        );
+        let decoded_accumulator = Accumulator::deserialize_from(&snapshot[4..])
+            .map_err(anyhow::Error::msg)?;
+        let mut decoded_accumulator_bytes = Vec::new();
+        decoded_accumulator
+            .serialize_into(&mut decoded_accumulator_bytes)
+            .map_err(anyhow::Error::msg)?;
+        assert_eq!(decoded_accumulator_bytes, expected_accumulator_bytes);
+
+        Ok(())
     }
 }

--- a/lib/authorization.rs
+++ b/lib/authorization.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::types::{
-    Address, AuthorizedTransaction, Body, GetAddress, Transaction, Verify,
-    VerifyingKey,
+    ADDRESS_SIZE, Address, AuthorizedTransaction, Body, GetAddress,
+    Transaction, Verify, VerifyingKey,
 };
 
 pub use ed25519_dalek::{SignatureError, Signer, SigningKey, Verifier};
@@ -151,7 +151,7 @@ impl Verify for Authorization {
 pub fn get_address(verifying_key: &VerifyingKey) -> Address {
     let mut hasher = blake3::Hasher::new();
     let mut reader = hasher.update(&verifying_key.to_bytes()).finalize_xof();
-    let mut output: [u8; 20] = [0; 20];
+    let mut output: [u8; ADDRESS_SIZE] = [0; ADDRESS_SIZE];
     reader.fill(&mut output);
     Address(output)
 }

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -511,17 +511,19 @@ where
     ) -> Result<Vec<(OutPoint, SpentOutput)>, Error> {
         let rotxn = self.env.read_txn()?;
         let mut spent = vec![];
+
         for outpoint in outpoints {
             let outpoint_key = OutPointKey::from_outpoint(outpoint);
-            if let Some(output) = self
+            if let Some(entry) = self
                 .state
                 .stxos()
                 .try_get(&rotxn, &outpoint_key)
                 .map_err(state::Error::from)?
             {
-                spent.push((*outpoint, output));
+                spent.push((*outpoint, entry.output));
             }
         }
+
         Ok(spent)
     }
 
@@ -564,9 +566,14 @@ where
     pub fn get_utxos_by_addresses(
         &self,
         addresses: &HashSet<Address>,
+        height_threshold: u32,
     ) -> Result<HashMap<OutPoint, FilledOutput>, Error> {
         let rotxn = self.env.read_txn()?;
-        let utxos = self.state.get_utxos_by_addresses(&rotxn, addresses)?;
+        let utxos = self.state.get_utxos_by_addresses(
+            &rotxn,
+            addresses,
+            height_threshold,
+        )?;
         Ok(utxos)
     }
 

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -5,7 +5,7 @@ use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
     sync::Arc,
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use error_fatality::{Nested as _, Split};
@@ -137,6 +137,15 @@ impl From<net::Error> for Error {
     }
 }
 
+const TXDB_PRUNE_INTERVAL_BLOCKS: u32 = 144 * 7;
+const TXDB_RETENTION_SECS: u64 = 28 * 24 * 3600;
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
 fn connect_tip_(
     rwtxn: &mut RwTxn<'_>,
     archive: &Archive,
@@ -147,21 +156,53 @@ fn connect_tip_(
     two_way_peg_data: &mainchain::TwoWayPegData,
 ) -> Result<(), Error> {
     let block_hash = header.hash();
+    let now = unix_now();
+
+    // Prevalidate explicitly so the filled transactions can also populate txdb.
+    let prevalidated = state.prevalidate_block(rwtxn, header, body)?;
+    let block_height = prevalidated.next_height;
+
+    archive.put_txdb_for_connected_block(
+        rwtxn,
+        block_hash,
+        block_height,
+        body,
+        &prevalidated.filled_transactions,
+        now,
+    )?;
+
+    // Consumes `prevalidated`. If this fails, the enclosing transaction—and
+    // therefore the txdb writes above—will be rolled back.
+    state.connect_prevalidated_block(rwtxn, header, body, prevalidated)?;
+
     if tracing::enabled!(tracing::Level::DEBUG) {
-        let merkle_root =
-            Body::compute_merkle_root(&body.coinbase, &body.transactions);
-        let height = state.try_get_height(rwtxn)?;
-        state.apply_block(rwtxn, header, body)?;
-        tracing::debug!(?height, %merkle_root, %block_hash, "connected body")
-    } else {
-        state.apply_block(rwtxn, header, body)?;
+        tracing::debug!(
+            height = block_height,
+            %block_hash,
+            "connected body"
+        );
     }
-    let () = state.connect_two_way_peg_data(rwtxn, two_way_peg_data)?;
-    let () = archive.put_header(rwtxn, header)?;
-    let () = archive.put_body(rwtxn, block_hash, body)?;
+
+    state.connect_two_way_peg_data(rwtxn, two_way_peg_data)?;
+    archive.put_header(rwtxn, header)?;
+    archive.put_body(rwtxn, block_hash, body)?;
+
     for transaction in &body.transactions {
-        let () = mempool.delete(rwtxn, transaction.txid())?;
+        mempool.delete(rwtxn, transaction.txid())?;
     }
+
+    if block_height > 0 && block_height % TXDB_PRUNE_INTERVAL_BLOCKS == 0 {
+        let cutoff = now.saturating_sub(TXDB_RETENTION_SECS);
+        let pruned = archive.prune_txdb_older_than(rwtxn, cutoff)?;
+
+        tracing::debug!(
+            pruned,
+            cutoff,
+            height = block_height,
+            "pruned old txdb entries"
+        );
+    }
+
     Ok(())
 }
 
@@ -257,11 +298,22 @@ fn disconnect_tip_(
             block_info: block_infos.into_iter().rev().collect(),
         }
     };
-    let () = state.disconnect_two_way_peg_data(rwtxn, &two_way_peg_data)?;
-    let () = state.disconnect_tip(rwtxn, &tip_header, &tip_body)?;
+
+    state.disconnect_two_way_peg_data(rwtxn, &two_way_peg_data)?;
+    state.disconnect_tip(rwtxn, &tip_header, &tip_body)?;
+
+    let pruned = archive.prune_txdb_block(rwtxn, tip_block_hash)?;
+
+    tracing::debug!(
+        %tip_block_hash,
+        pruned,
+        "pruned txdb entries for disconnected block"
+    );
+
     for transaction in tip_body.authorized_transactions().iter().rev() {
         mempool.put(rwtxn, transaction)?;
     }
+
     Ok(())
 }
 

--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -6,10 +6,10 @@ use sneed::{RoTxn, RwTxn};
 use crate::{
     state::{Error, PrevalidatedBlock, State, amm, dutch_auction, error},
     types::{
-        AmountOverflowError, Authorization, BitAssetId, Body, FilledOutput,
-        FilledOutputContent, GetAddress as _, GetBitcoinValue as _, Header,
-        InPoint, OutPoint, OutPointKey, OutputContent, SpentOutput, TxData,
-        Verify as _,
+        AddressOutPointKey, AmountOverflowError, Authorization, BitAssetId,
+        Body, FilledOutput, FilledOutputContent, GetAddress as _,
+        GetBitcoinValue as _, Header, InPoint, OutPoint, OutPointKey,
+        OutputContent, SpentOutput, TxData, Verify as _,
     },
 };
 
@@ -215,8 +215,6 @@ pub fn connect_prevalidated(
         .sum::<usize>()
         + body.coinbase.len();
 
-    // Use Vec + sort_unstable instead of individual DB operations for better performance
-    let mut utxo_deletes: Vec<OutPointKey> = Vec::with_capacity(total_inputs);
     let mut stxo_puts: Vec<(OutPointKey, SpentOutput)> =
         Vec::with_capacity(total_inputs);
     let mut utxo_puts: Vec<(OutPointKey, FilledOutput)> =
@@ -262,7 +260,6 @@ pub fn connect_prevalidated(
         // Process inputs
         for (vin, input) in filled_tx.inputs().iter().enumerate() {
             let key = OutPointKey::from_outpoint(input);
-            // Reuse prevalidated spent UTXO instead of reading from DB
             let prev_utxo = filled_tx.spent_utxos[vin].clone();
             let spent_output = SpentOutput {
                 output: prev_utxo,
@@ -271,7 +268,6 @@ pub fn connect_prevalidated(
                     vin: vin as u32,
                 },
             };
-            utxo_deletes.push(key);
             stxo_puts.push((key, spent_output));
         }
 
@@ -365,22 +361,20 @@ pub fn connect_prevalidated(
         }
     }
 
-    // Sort all vectors in parallel for optimal cursor access
-    utxo_deletes.par_sort_unstable();
     stxo_puts.par_sort_unstable_by_key(|(key, _)| *key);
     utxo_puts.par_sort_unstable_by_key(|(key, _)| *key);
 
-    // Apply all database operations using pre-sorted keys for optimal B-tree access
-    for key in &utxo_deletes {
-        state.utxos.delete(rwtxn, key)?;
+    for (key, spent_output) in stxo_puts {
+        if !state.spend_utxo(rwtxn, key, spent_output)? {
+            return Err(error::NoUtxo {
+                outpoint: key.to_outpoint(),
+            }
+            .into());
+        }
     }
 
-    for (key, spent_output) in &stxo_puts {
-        state.stxos.put(rwtxn, key, spent_output)?;
-    }
-
-    for (key, filled_output) in &utxo_puts {
-        state.utxos.put(rwtxn, key, filled_output)?;
+    for (key, filled_output) in utxo_puts {
+        state.put_utxo(rwtxn, key, filled_output, prevalidated.next_height)?;
     }
 
     // Update tip and height using precomputed values
@@ -406,6 +400,7 @@ pub fn connect(
         };
         return Err(Error::InvalidHeader(err));
     }
+
     let merkle_root =
         Body::compute_merkle_root(&body.coinbase, &body.transactions);
     if merkle_root != header.merkle_root {
@@ -415,12 +410,14 @@ pub fn connect(
         };
         return Err(err);
     }
+
     for (vout, output) in body.coinbase.iter().enumerate() {
         let outpoint = OutPoint::Coinbase {
             merkle_root: header.merkle_root,
             vout: vout as u32,
         };
         let outpoint_key = OutPointKey::from_outpoint(&outpoint);
+
         let filled_content = match output.content.clone() {
             OutputContent::Bitcoin(value) => {
                 FilledOutputContent::Bitcoin(value)
@@ -436,22 +433,27 @@ pub fn connect(
                 return Err(Error::BadCoinbaseOutputContent);
             }
         };
+
         let filled_output = FilledOutput {
             address: output.address,
             content: filled_content,
             memo: output.memo.clone(),
         };
-        state.utxos.put(rwtxn, &outpoint_key, &filled_output)?;
+
+        state.put_utxo(rwtxn, outpoint_key, filled_output, height)?;
     }
+
     for transaction in &body.transactions {
         let filled_tx = state.fill_transaction(rwtxn, transaction)?;
         let txid = filled_tx.txid();
+
         for (vin, input) in filled_tx.inputs().iter().enumerate() {
             let input_key = OutPointKey::from_outpoint(input);
             let spent_output = state
                 .utxos
                 .try_get(rwtxn, &input_key)?
                 .ok_or(error::NoUtxo { outpoint: *input })?;
+
             let spent_output = SpentOutput {
                 output: spent_output,
                 inpoint: InPoint::Regular {
@@ -459,21 +461,26 @@ pub fn connect(
                     vin: vin as u32,
                 },
             };
-            state.utxos.delete(rwtxn, &input_key)?;
-            state.stxos.put(rwtxn, &input_key, &spent_output)?;
+
+            if !state.spend_utxo(rwtxn, input_key, spent_output)? {
+                return Err(error::NoUtxo { outpoint: *input }.into());
+            }
         }
+
         let Some(filled_outputs) = filled_tx.filled_outputs() else {
             let err = error::FillTxOutputContents(Box::new(filled_tx));
             return Err(err.into());
         };
-        for (vout, filled_output) in filled_outputs.iter().enumerate() {
+
+        for (vout, filled_output) in filled_outputs.into_iter().enumerate() {
             let outpoint = OutPoint::Regular {
                 txid,
                 vout: vout as u32,
             };
             let outpoint_key = OutPointKey::from_outpoint(&outpoint);
-            state.utxos.put(rwtxn, &outpoint_key, filled_output)?;
+            state.put_utxo(rwtxn, outpoint_key, filled_output, height)?;
         }
+
         match &transaction.data {
             None => (),
             Some(TxData::AmmBurn { .. }) => {
@@ -548,9 +555,11 @@ pub fn connect(
             }
         }
     }
+
     let block_hash = header.hash();
     state.tip.put(rwtxn, &(), &block_hash)?;
     state.height.put(rwtxn, &(), &height)?;
+
     Ok(())
 }
 
@@ -568,6 +577,7 @@ pub fn disconnect_tip(
         };
         return Err(Error::InvalidHeader(err));
     }
+
     let merkle_root =
         Body::compute_merkle_root(&body.coinbase, &body.transactions);
     if merkle_root != header.merkle_root {
@@ -577,14 +587,17 @@ pub fn disconnect_tip(
         };
         return Err(err);
     }
+
     let height = state
         .try_get_height(rwtxn)?
         .expect("Height should not be None");
-    // revert txs, last-to-first
+
+    // Revert transactions, last-to-first.
     body.transactions.iter().rev().try_for_each(|tx| {
         let txid = tx.txid();
         let filled_tx = state.fill_transaction_from_stxos(rwtxn, tx.clone())?;
-        // revert transaction effects
+
+        // Revert transaction data effects.
         match &tx.data {
             None => (),
             Some(TxData::AmmBurn { .. }) => {
@@ -652,31 +665,31 @@ pub fn disconnect_tip(
                 )?;
             }
         }
-        // delete UTXOs, last-to-first
+
+        // Delete transaction UTXOs, last-to-first.
         tx.outputs.iter().enumerate().rev().try_for_each(
-            |(vout, _output)| {
+            |(vout, output)| {
                 let outpoint = OutPoint::Regular {
                     txid,
                     vout: vout as u32,
                 };
                 let outpoint_key = OutPointKey::from_outpoint(&outpoint);
-                if state.utxos.delete(rwtxn, &outpoint_key)? {
+                let address_key =
+                    AddressOutPointKey::new(output.address, outpoint_key);
+
+                if state.delete_utxo(rwtxn, &address_key)? {
                     Ok::<_, Error>(())
                 } else {
                     Err(error::NoUtxo { outpoint }.into())
                 }
             },
         )?;
-        // unspend STXOs, last-to-first
+
+        // Restore spent inputs, last-to-first.
         tx.inputs.iter().rev().try_for_each(|outpoint| {
             let outpoint_key = OutPointKey::from_outpoint(outpoint);
-            if let Some(spent_output) =
-                state.stxos.try_get(rwtxn, &outpoint_key)?
-            {
-                state.stxos.delete(rwtxn, &outpoint_key)?;
-                state
-                    .utxos
-                    .put(rwtxn, &outpoint_key, &spent_output.output)?;
+
+            if state.unspend_utxo(rwtxn, &outpoint_key)? {
                 Ok(())
             } else {
                 Err(Error::NoStxo {
@@ -685,21 +698,28 @@ pub fn disconnect_tip(
             }
         })
     })?;
-    // delete coinbase UTXOs, last-to-first
-    body.coinbase.iter().enumerate().rev().try_for_each(
-        |(vout, _output)| {
+
+    // Delete coinbase UTXOs, last-to-first.
+    body.coinbase
+        .iter()
+        .enumerate()
+        .rev()
+        .try_for_each(|(vout, output)| {
             let outpoint = OutPoint::Coinbase {
                 merkle_root: header.merkle_root,
                 vout: vout as u32,
             };
             let outpoint_key = OutPointKey::from_outpoint(&outpoint);
-            if state.utxos.delete(rwtxn, &outpoint_key)? {
+            let address_key =
+                AddressOutPointKey::new(output.address, outpoint_key);
+
+            if state.delete_utxo(rwtxn, &address_key)? {
                 Ok::<_, Error>(())
             } else {
                 Err(error::NoUtxo { outpoint }.into())
             }
-        },
-    )?;
+        })?;
+
     match (header.prev_side_hash, height) {
         (None, 0) => {
             state.tip.delete(rwtxn, &())?;
@@ -711,6 +731,7 @@ pub fn disconnect_tip(
             state.height.put(rwtxn, &(), &(height - 1))?;
         }
     }
+
     Ok(())
 }
 
@@ -818,23 +839,25 @@ mod test {
             )?;
             let seq = state.bitassets.next_seq(&rwtxn)?;
             anyhow::ensure!(seq == BitAssetSeqId(1));
-            state.utxos.put(
+            state.put_utxo(
                 &mut rwtxn,
-                &OutPointKey::from_outpoint(&bitasset_outpoint),
-                &FilledOutput {
+                OutPointKey::from_outpoint(&bitasset_outpoint),
+                FilledOutput {
                     address,
                     content: FilledOutputContent::BitAsset(bitasset_id, 5),
                     memo: Vec::new(),
                 },
+                0,
             )?;
-            state.utxos.put(
+            state.put_utxo(
                 &mut rwtxn,
-                &OutPointKey::from_outpoint(&control_outpoint),
-                &FilledOutput {
+                OutPointKey::from_outpoint(&control_outpoint),
+                FilledOutput {
                     address,
                     content: FilledOutputContent::BitAssetControl(bitasset_id),
                     memo: Vec::new(),
                 },
+                0,
             )?;
             rwtxn.commit()?;
         }

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -10,12 +10,12 @@ use sneed::{DatabaseUnique, RoDatabaseUnique, RoTxn, RwTxn, UnitKey};
 use crate::{
     authorization::Authorization,
     types::{
-        Address, AmountOverflowError, Authorized, AuthorizedTransaction,
-        BitAssetId, BlockHash, Body, FilledOutput, FilledTransaction,
-        GetAddress as _, GetBitcoinValue as _, Header, InPoint, M6id, OutPoint,
-        OutPointKey, SpentOutput, Transaction, TxData, VERSION, Verify as _,
-        Version, WithdrawalBundle, WithdrawalBundleStatus,
-        proto::mainchain::TwoWayPegData,
+        Address, AddressOutPointKey, AmountOverflowError, Authorized,
+        AuthorizedTransaction, BitAssetId, BlockHash, Body, FilledOutput,
+        FilledTransaction, GetAddress as _, GetBitcoinValue as _, Header,
+        InPoint, M6id, OutPoint, OutPointKey, SpentOutput, Transaction, TxData,
+        VERSION, Verify as _, Version, WithdrawalBundle,
+        WithdrawalBundleStatus, proto::mainchain::TwoWayPegData,
     },
     util::Watchable,
 };
@@ -68,6 +68,12 @@ type WithdrawalBundlesDb = DatabaseUnique<
     )>,
 >;
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SpentUtxoEntry {
+    pub created_height: u32,
+    pub output: SpentOutput,
+}
+
 #[derive(Clone)]
 pub struct State {
     /// Current tip
@@ -80,7 +86,9 @@ pub struct State {
     /// Associates Dutch auction sequence numbers with auction state
     dutch_auctions: dutch_auction::Db,
     utxos: DatabaseUnique<OutPointKey, SerdeBincode<FilledOutput>>,
-    stxos: DatabaseUnique<OutPointKey, SerdeBincode<SpentOutput>>,
+    utxo_heights_by_address:
+        DatabaseUnique<AddressOutPointKey, SerdeBincode<u32>>,
+    stxos: DatabaseUnique<OutPointKey, SerdeBincode<SpentUtxoEntry>>,
     /// Pending withdrawal bundle. MUST exist in withdrawal_bundles
     pending_withdrawal_bundle: DatabaseUnique<UnitKey, SerdeBincode<M6id>>,
     /// Latest failed (known) withdrawal bundle
@@ -104,7 +112,7 @@ pub struct State {
 }
 
 impl State {
-    pub const NUM_DBS: u32 = bitassets::Dbs::NUM_DBS + 12;
+    pub const NUM_DBS: u32 = bitassets::Dbs::NUM_DBS + 13;
 
     pub fn new(env: &sneed::Env) -> Result<Self, Error> {
         let mut rwtxn = env.write_txn()?;
@@ -115,6 +123,8 @@ impl State {
         let dutch_auctions =
             DatabaseUnique::create(env, &mut rwtxn, "dutch_auctions")?;
         let utxos = DatabaseUnique::create(env, &mut rwtxn, "utxos")?;
+        let utxo_heights_by_address =
+            DatabaseUnique::create(env, &mut rwtxn, "utxo_heights_by_address")?;
         let stxos = DatabaseUnique::create(env, &mut rwtxn, "stxos")?;
         let pending_withdrawal_bundle = DatabaseUnique::create(
             env,
@@ -147,6 +157,7 @@ impl State {
             bitassets,
             dutch_auctions,
             utxos,
+            utxo_heights_by_address,
             stxos,
             pending_withdrawal_bundle,
             latest_failed_withdrawal_bundle,
@@ -180,7 +191,7 @@ impl State {
 
     pub fn stxos(
         &self,
-    ) -> &RoDatabaseUnique<OutPointKey, SerdeBincode<SpentOutput>> {
+    ) -> &RoDatabaseUnique<OutPointKey, SerdeBincode<SpentUtxoEntry>> {
         &self.stxos
     }
 
@@ -222,13 +233,25 @@ impl State {
         &self,
         rotxn: &RoTxn,
         addresses: &HashSet<Address>,
+        height_threshold: u32,
     ) -> Result<HashMap<OutPoint, FilledOutput>, Error> {
-        let utxos: HashMap<OutPoint, FilledOutput> = self
-            .utxos
-            .iter(rotxn)?
-            .filter(|(_, output)| Ok(addresses.contains(&output.address)))
-            .map(|(key, output)| Ok((key.to_outpoint(), output)))
-            .collect()?;
+        let mut utxos = HashMap::new();
+        for address in addresses {
+            let start = AddressOutPointKey::start(*address);
+            let end = AddressOutPointKey::end(*address);
+            let mut iter = self
+                .utxo_heights_by_address
+                .range(rotxn, &(start..=end))
+                .map_err(sneed::db::Error::from)?;
+            while let Some((key, created_height)) = iter.next()? {
+                if created_height >= height_threshold {
+                    let outpoint_key = key.outpoint_key();
+                    let outpoint = outpoint_key.to_outpoint();
+                    let output = self.utxos.get(rotxn, &outpoint_key)?;
+                    utxos.insert(outpoint, output);
+                }
+            }
+        }
         Ok(utxos)
     }
 
@@ -300,13 +323,13 @@ impl State {
                 .try_get(rotxn, &key)?
                 .ok_or(Error::NoStxo { outpoint: *input })?;
             assert_eq!(
-                stxo.inpoint,
+                stxo.output.inpoint,
                 InPoint::Regular {
                     txid,
                     vin: vin as u32
                 }
             );
-            spent_utxos.push(stxo.output);
+            spent_utxos.push(stxo.output.output);
         }
         spent_utxos.reverse();
         Ok(FilledTransaction {
@@ -689,7 +712,8 @@ impl State {
         let mut total_deposit_stxo_value = bitcoin::Amount::ZERO;
         let mut total_withdrawal_stxo_value = bitcoin::Amount::ZERO;
         self.stxos.iter(rotxn)?.map_err(Error::from).for_each(
-            |(outpoint_key, spent_output)| {
+            |(outpoint_key, spent_entry)| {
+                let spent_output = spent_entry.output;
                 let outpoint = outpoint_key.to_outpoint();
                 if let OutPoint::Deposit(_) = outpoint {
                     total_deposit_stxo_value = total_deposit_stxo_value
@@ -773,6 +797,69 @@ impl State {
     ) -> Result<(), Error> {
         block::connect_prevalidated(self, rwtxn, header, body, prevalidated)
     }
+
+    fn put_utxo(
+        &self,
+        rwtxn: &mut RwTxn,
+        key: OutPointKey,
+        output: FilledOutput,
+        created_height: u32,
+    ) -> Result<AddressOutPointKey, sneed::db::Error> {
+        let address_key = AddressOutPointKey::new(output.address, key);
+        self.utxo_heights_by_address.put(
+            rwtxn,
+            &address_key,
+            &created_height,
+        )?;
+        self.utxos.put(rwtxn, &key, &output)?;
+        Ok(address_key)
+    }
+
+    fn delete_utxo(
+        &self,
+        rwtxn: &mut RwTxn,
+        key: &AddressOutPointKey,
+    ) -> Result<bool, sneed::db::Error> {
+        let db1 = self.utxo_heights_by_address.delete(rwtxn, &key)?;
+        let db2 = self.utxos.delete(rwtxn, &key.outpoint_key())?;
+        Ok(db1 && db2)
+    }
+
+    fn spend_utxo(
+        &self,
+        rwtxn: &mut RwTxn,
+        key: OutPointKey,
+        spent_output: SpentOutput,
+    ) -> Result<bool, sneed::db::Error> {
+        let address_key =
+            AddressOutPointKey::new(spent_output.output.address, key);
+        let Some(created_height) =
+            self.utxo_heights_by_address.try_get(rwtxn, &address_key)?
+        else {
+            return Ok(false);
+        };
+
+        let entry = SpentUtxoEntry {
+            created_height,
+            output: spent_output,
+        };
+
+        self.stxos.put(rwtxn, &key, &entry)?;
+        self.delete_utxo(rwtxn, &address_key)
+    }
+
+    fn unspend_utxo(
+        &self,
+        rwtxn: &mut RwTxn,
+        key: &OutPointKey,
+    ) -> Result<bool, sneed::db::Error> {
+        let Some(entry) = self.stxos.try_get(rwtxn, key)? else {
+            return Ok(false);
+        };
+
+        self.put_utxo(rwtxn, *key, entry.output.output, entry.created_height)?;
+        Ok(self.stxos.delete(rwtxn, key)?)
+    }
 }
 
 impl Watchable<()> for State {
@@ -853,8 +940,7 @@ mod test {
         let output = bitcoin_filled_output(address, value_sats);
         let mut rwtxn = env.write_txn().unwrap();
         state
-            .utxos
-            .put(&mut rwtxn, &OutPointKey::from(&outpoint), &output)
+            .put_utxo(&mut rwtxn, OutPointKey::from(&outpoint), output, 0)
             .unwrap();
         rwtxn.commit().unwrap();
         outpoint
@@ -1059,10 +1145,11 @@ mod test {
                 )?,
                 vout: 0,
             });
-            state.utxos.put(
+            state.put_utxo(
                 &mut rwtxn,
-                &OutPointKey::from(&deposit_utxo_op),
-                &bitcoin_filled_output(Address::ALL_ZEROS, 50),
+                OutPointKey::from(&deposit_utxo_op),
+                bitcoin_filled_output(Address::ALL_ZEROS, 50),
+                0,
             )?;
 
             // Two spent DEPOSIT STXOs: 100 + 100 sats.
@@ -1071,11 +1158,14 @@ mod test {
                     txid: bitcoin::Txid::from_byte_array([i; 32]),
                     vout: 0,
                 });
-                let stxo = SpentOutput {
-                    output: bitcoin_filled_output(Address::ALL_ZEROS, sats),
-                    inpoint: InPoint::Regular {
-                        txid: [i; 32].into(),
-                        vin: 0,
+                let stxo = super::SpentUtxoEntry {
+                    created_height: 0,
+                    output: SpentOutput {
+                        output: bitcoin_filled_output(Address::ALL_ZEROS, sats),
+                        inpoint: InPoint::Regular {
+                            txid: [i; 32].into(),
+                            vin: 0,
+                        },
                     },
                 };
                 state
@@ -1089,12 +1179,15 @@ mod test {
                     txid: [i; 32].into(),
                     vout: 0,
                 };
-                let stxo = SpentOutput {
-                    output: bitcoin_filled_output(Address::ALL_ZEROS, sats),
-                    inpoint: InPoint::Withdrawal {
-                        m6id: crate::types::M6id(
-                            bitcoin::Txid::from_byte_array([i; 32]),
-                        ),
+                let stxo = super::SpentUtxoEntry {
+                    created_height: 0,
+                    output: SpentOutput {
+                        output: bitcoin_filled_output(Address::ALL_ZEROS, sats),
+                        inpoint: InPoint::Withdrawal {
+                            m6id: crate::types::M6id(
+                                bitcoin::Txid::from_byte_array([i; 32]),
+                            ),
+                        },
                     },
                 };
                 state
@@ -1117,6 +1210,79 @@ mod test {
             expected_sidechain_wealth,
             sidechain_wealth,
         );
+        Ok(())
+    }
+
+    #[test]
+    fn address_utxo_index_stores_height_and_restores_on_unspend()
+    -> anyhow::Result<()> {
+        use std::collections::HashSet;
+
+        let (_temp_dir, env, state) = fresh_state(
+            "address_utxo_index_stores_height_and_restores_on_unspend",
+        )?;
+        let address = Address([1; 20]);
+        let outpoint = OutPoint::Regular {
+            txid: Txid([2; 32]),
+            vout: 0,
+        };
+        let key = OutPointKey::from_outpoint(&outpoint);
+        let output = bitcoin_filled_output(address, 42);
+        let created_height = 7;
+        let addresses = HashSet::from([address]);
+
+        {
+            let mut rwtxn = env.write_txn()?;
+            let address_key = state.put_utxo(
+                &mut rwtxn,
+                key,
+                output.clone(),
+                created_height,
+            )?;
+            anyhow::ensure!(
+                state.utxo_heights_by_address.get(&rwtxn, &address_key)?
+                    == created_height
+            );
+            rwtxn.commit()?;
+        }
+
+        {
+            let rotxn = env.read_txn()?;
+            let indexed =
+                state.get_utxos_by_addresses(&rotxn, &addresses, 0)?;
+            anyhow::ensure!(indexed.get(&outpoint) == Some(&output));
+            let above_height = state.get_utxos_by_addresses(
+                &rotxn,
+                &addresses,
+                created_height + 1,
+            )?;
+            anyhow::ensure!(above_height.is_empty());
+        }
+
+        {
+            let mut rwtxn = env.write_txn()?;
+            let spent_output = SpentOutput {
+                output: output.clone(),
+                inpoint: InPoint::Regular {
+                    txid: Txid([3; 32]),
+                    vin: 0,
+                },
+            };
+            state.spend_utxo(&mut rwtxn, key, spent_output)?;
+            state.unspend_utxo(&mut rwtxn, &key)?;
+            rwtxn.commit()?;
+        }
+
+        let rotxn = env.read_txn()?;
+        let restored =
+            state.get_utxos_by_addresses(&rotxn, &addresses, created_height)?;
+        anyhow::ensure!(restored.get(&outpoint) == Some(&output));
+        let above_height = state.get_utxos_by_addresses(
+            &rotxn,
+            &addresses,
+            created_height + 1,
+        )?;
+        anyhow::ensure!(above_height.is_empty());
         Ok(())
     }
 }

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -773,17 +773,6 @@ impl State {
     ) -> Result<(), Error> {
         block::connect_prevalidated(self, rwtxn, header, body, prevalidated)
     }
-
-    pub fn apply_block(
-        &self,
-        rwtxn: &mut RwTxn,
-        header: &Header,
-        body: &Body,
-    ) -> Result<(), Error> {
-        let prevalidated = self.prevalidate_block(rwtxn, header, body)?;
-        self.connect_prevalidated_block(rwtxn, header, body, prevalidated)?;
-        Ok(())
-    }
 }
 
 impl Watchable<()> for State {

--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -1275,7 +1275,14 @@ mod test {
         };
         {
             let mut rwtxn = env.write_txn()?;
-            state.apply_block(&mut rwtxn, &genesis, &empty_body)?;
+            let prevalidated =
+                state.prevalidate_block(&rwtxn, &genesis, &empty_body)?;
+            state.connect_prevalidated_block(
+                &mut rwtxn,
+                &genesis,
+                &empty_body,
+                prevalidated,
+            )?;
             state.connect_two_way_peg_data(
                 &mut rwtxn,
                 &TwoWayPegData::default(),
@@ -1311,7 +1318,14 @@ mod test {
         };
         {
             let mut rwtxn = env.write_txn()?;
-            state.apply_block(&mut rwtxn, &block1, &empty_body)?;
+            let prevalidated =
+                state.prevalidate_block(&rwtxn, &block1, &empty_body)?;
+            state.connect_prevalidated_block(
+                &mut rwtxn,
+                &block1,
+                &empty_body,
+                prevalidated,
+            )?;
             state.connect_two_way_peg_data(&mut rwtxn, &deposit_twpd)?;
             anyhow::ensure!(
                 state.utxos.try_get(&rwtxn, &deposit_key)?.is_some()

--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -12,10 +12,11 @@ use crate::{
         rollback::{HeightStamped, RollBack},
     },
     types::{
-        AggregatedWithdrawal, AmountOverflowError, FilledOutput,
-        FilledOutputContent, InPoint, M6id, OutPoint, OutPointKey, SpentOutput,
-        WithdrawalBundle, WithdrawalBundleEvent, WithdrawalBundleEventStatus,
-        WithdrawalBundleStatus, WithdrawalOutputContent,
+        AddressOutPointKey, AggregatedWithdrawal, AmountOverflowError,
+        FilledOutput, FilledOutputContent, InPoint, M6id, OutPoint,
+        OutPointKey, SpentOutput, WithdrawalBundle, WithdrawalBundleEvent,
+        WithdrawalBundleEventStatus, WithdrawalBundleStatus,
+        WithdrawalOutputContent,
         proto::mainchain::{BlockEvent, TwoWayPegData},
     },
 };
@@ -138,10 +139,12 @@ fn connect_withdrawal_bundle_submitted(
             %m6id,
             "Pending withdrawal bundle submission confirmed"
         );
+
         let (bundle, mut bundle_status) = state
             .withdrawal_bundles
             .try_get(rwtxn, &m6id)?
             .ok_or(error::PendingWithdrawalBundleUnknown(m6id))?;
+
         let bundle = match bundle {
             WithdrawalBundleInfo::Known(bundle) => bundle,
             WithdrawalBundleInfo::Unknown
@@ -150,20 +153,16 @@ fn connect_withdrawal_bundle_submitted(
                 return Err(err.into());
             }
         };
-        for (outpoint, spend_output) in bundle.spend_utxos() {
-            let outpoint_key = OutPointKey::from_outpoint(outpoint);
-            if !state.utxos.delete(rwtxn, &outpoint_key)? {
+
+        for (outpoint, output) in bundle.spend_utxos() {
+            if !spend_withdrawal_utxo(state, rwtxn, m6id, outpoint, output)? {
                 return Err(error::NoUtxo {
                     outpoint: *outpoint,
                 }
                 .into());
-            };
-            let spent_output = SpentOutput {
-                output: spend_output.clone(),
-                inpoint: InPoint::Withdrawal { m6id },
-            };
-            state.stxos.put(rwtxn, &outpoint_key, &spent_output)?;
+            }
         }
+
         assert_eq!(
             bundle_status.latest().value,
             WithdrawalBundleStatus::Pending
@@ -171,6 +170,7 @@ fn connect_withdrawal_bundle_submitted(
         bundle_status
             .push(WithdrawalBundleStatus::Submitted, block_height)
             .expect("push submitted status should be valid");
+
         state.withdrawal_bundles.put(
             rwtxn,
             &m6id,
@@ -182,10 +182,11 @@ fn connect_withdrawal_bundle_submitted(
     {
         match (&bundle, bundle_status.latest().value) {
             (_, WithdrawalBundleStatus::Confirmed) => {
-                let err = error::ConnectWithdrawalBundleSubmitted::ConfirmedResubmitted {
-                    event_block_hash: *event_block_hash,
-                    m6id
-                };
+                let err = error::ConnectWithdrawalBundleSubmitted::
+                    ConfirmedResubmitted {
+                        event_block_hash: *event_block_hash,
+                        m6id,
+                    };
                 return Err(err);
             }
             (
@@ -205,7 +206,11 @@ fn connect_withdrawal_bundle_submitted(
                 WithdrawalBundleInfo::Known(_),
                 WithdrawalBundleStatus::Dropped,
             ) => {
-                tracing::warn!(%event_block_hash, %m6id, "dropped bundle submitted");
+                tracing::warn!(
+                    %event_block_hash,
+                    %m6id,
+                    "dropped bundle submitted"
+                );
             }
             (
                 WithdrawalBundleInfo::Unknown
@@ -245,31 +250,39 @@ fn connect_withdrawal_bundle_submitted(
                 WithdrawalBundleInfo::Known(_) | WithdrawalBundleInfo::Unknown,
                 WithdrawalBundleStatus::Failed,
             ) => {
-                tracing::warn!(%event_block_hash, %m6id, "failed bundle resubmitted");
+                tracing::warn!(
+                    %event_block_hash,
+                    %m6id,
+                    "failed bundle resubmitted"
+                );
             }
             (
                 WithdrawalBundleInfo::UnknownConfirmed { spend_utxos: _ },
                 WithdrawalBundleStatus::Failed,
             ) => {
-                let err = error::ConnectWithdrawalBundleSubmitted::UnknownConfirmedFailed {
-                    m6id,
-                    failed_block_height: bundle_status.latest().height,
-                };
+                let err = error::ConnectWithdrawalBundleSubmitted::
+                    UnknownConfirmedFailed {
+                        m6id,
+                        failed_block_height: bundle_status.latest().height,
+                    };
                 return Err(err);
             }
         }
+
         bundle_status
             .push(WithdrawalBundleStatus::SubmittedUnexpected, block_height)
             .expect("push submitted unexpected status should be valid");
+
         state
             .withdrawal_bundles
-            .put(rwtxn, &m6id, &(bundle, bundle_status))?
+            .put(rwtxn, &m6id, &(bundle, bundle_status))?;
     } else {
         tracing::warn!(
             %event_block_hash,
             %m6id,
             "Unknown withdrawal bundle submitted"
         );
+
         state.withdrawal_bundles.put(
             rwtxn,
             &m6id,
@@ -281,7 +294,8 @@ fn connect_withdrawal_bundle_submitted(
                 ),
             ),
         )?;
-    };
+    }
+
     Ok(())
 }
 
@@ -296,15 +310,18 @@ fn connect_withdrawal_bundle_confirmed(
         .withdrawal_bundles
         .try_get(rwtxn, &m6id)?
         .ok_or(Error::UnknownWithdrawalBundle { m6id })?;
+
     if bundle_status.latest().value == WithdrawalBundleStatus::Confirmed {
         // Already applied
         return Ok(());
     }
+
     assert!(matches!(
         bundle_status.latest().value,
         WithdrawalBundleStatus::Submitted
             | WithdrawalBundleStatus::SubmittedUnexpected
     ));
+
     match &bundle {
         WithdrawalBundleInfo::UnknownConfirmed { spend_utxos: _ } => {
             return Err(Error::UnknownWithdrawalBundleReconfirmed {
@@ -324,24 +341,25 @@ fn connect_withdrawal_bundle_confirmed(
                     %m6id,
                     "Unknown withdrawal bundle confirmed, marking all UTXOs as spent"
                 );
+
                 let utxos: BTreeMap<OutPoint, _> = state
                     .utxos
                     .iter(rwtxn)
                     .map_err(Error::from)?
                     .map(|(key, output)| Ok((key.into(), output)))
                     .collect()?;
+
                 for (outpoint, output) in &utxos {
-                    let spent_output = SpentOutput {
-                        output: output.clone(),
-                        inpoint: InPoint::Withdrawal { m6id },
-                    };
-                    state.stxos.put(
-                        rwtxn,
-                        &OutPointKey::from(outpoint),
-                        &spent_output,
-                    )?;
+                    if !spend_withdrawal_utxo(
+                        state, rwtxn, m6id, outpoint, output,
+                    )? {
+                        return Err(error::NoUtxo {
+                            outpoint: *outpoint,
+                        }
+                        .into());
+                    }
                 }
-                state.utxos.clear(rwtxn)?;
+
                 bundle = WithdrawalBundleInfo::UnknownConfirmed {
                     spend_utxos: utxos,
                 };
@@ -365,9 +383,11 @@ fn connect_withdrawal_bundle_confirmed(
                     %m6id,
                     "Unexpected withdrawal bundle confirmed, marking bundle UTXOs as spent"
                 );
+
                 for (outpoint, output) in bundle.spend_utxos() {
-                    let outpoint_key = OutPointKey::from(outpoint);
-                    if !state.utxos.delete(rwtxn, &outpoint_key)? {
+                    if !spend_withdrawal_utxo(
+                        state, rwtxn, m6id, outpoint, output,
+                    )? {
                         return Err(
                             Error::UnexpectedWithdrawalBundleInsolvency {
                                 event_block_hash: *event_block_hash,
@@ -376,21 +396,19 @@ fn connect_withdrawal_bundle_confirmed(
                             },
                         );
                     }
-                    let spent_output = SpentOutput {
-                        output: output.clone(),
-                        inpoint: InPoint::Withdrawal { m6id },
-                    };
-                    state.stxos.put(rwtxn, &outpoint_key, &spent_output)?;
                 }
             }
         }
     }
+
     bundle_status
         .push(WithdrawalBundleStatus::Confirmed, block_height)
         .expect("Push confirmed status should be valid");
+
     state
         .withdrawal_bundles
         .put(rwtxn, &m6id, &(bundle, bundle_status))?;
+
     Ok(())
 }
 
@@ -403,20 +421,25 @@ fn connect_withdrawal_bundle_failed(
     tracing::debug!(
         %block_height,
         %m6id,
-        "Handling failed withdrawal bundle");
+        "Handling failed withdrawal bundle"
+    );
+
     let (bundle, mut bundle_status) = state
         .withdrawal_bundles
         .try_get(rwtxn, &m6id)?
         .ok_or_else(|| Error::UnknownWithdrawalBundle { m6id })?;
+
     if bundle_status.latest().value == WithdrawalBundleStatus::Failed {
         // Already applied
         return Ok(());
     }
+
     assert!(matches!(
         bundle_status.latest().value,
         WithdrawalBundleStatus::Submitted
             | WithdrawalBundleStatus::SubmittedUnexpected
     ));
+
     match &bundle {
         WithdrawalBundleInfo::Unknown
         | WithdrawalBundleInfo::UnknownConfirmed { .. } => (),
@@ -427,11 +450,16 @@ fn connect_withdrawal_bundle_failed(
             ) {
                 break 'known;
             }
-            for (outpoint, output) in bundle.spend_utxos() {
+
+            for outpoint in bundle.spend_utxos().keys() {
                 let outpoint_key = OutPointKey::from_outpoint(outpoint);
-                state.stxos.delete(rwtxn, &outpoint_key)?;
-                state.utxos.put(rwtxn, &outpoint_key, output)?;
+                if !state.unspend_utxo(rwtxn, &outpoint_key)? {
+                    return Err(Error::NoStxo {
+                        outpoint: *outpoint,
+                    });
+                }
             }
+
             let latest_failed_m6id = if let Some(mut latest_failed_m6id) =
                 state.latest_failed_withdrawal_bundle.try_get(rwtxn, &())?
             {
@@ -442,6 +470,7 @@ fn connect_withdrawal_bundle_failed(
             } else {
                 RollBack::<HeightStamped<_>>::new(m6id, block_height)
             };
+
             state.latest_failed_withdrawal_bundle.put(
                 rwtxn,
                 &(),
@@ -449,12 +478,15 @@ fn connect_withdrawal_bundle_failed(
             )?;
         }
     }
+
     bundle_status
         .push(WithdrawalBundleStatus::Failed, block_height)
         .expect("Push failed status should be valid");
+
     state
         .withdrawal_bundles
         .put(rwtxn, &m6id, &(bundle, bundle_status))?;
+
     Ok(())
 }
 
@@ -510,7 +542,8 @@ fn connect_2wpd_event(
             let outpoint = OutPoint::Deposit(deposit.outpoint);
             let output = deposit.output.clone();
             let outpoint_key = OutPointKey::from_outpoint(&outpoint);
-            state.utxos.put(rwtxn, &outpoint_key, &output)?;
+
+            state.put_utxo(rwtxn, outpoint_key, output, block_height)?;
             *latest_deposit_block_hash = Some(event_block_hash);
         }
         BlockEvent::WithdrawalBundle(withdrawal_bundle_event) => {
@@ -524,6 +557,7 @@ fn connect_2wpd_event(
             *latest_withdrawal_bundle_event_block_hash = Some(event_block_hash);
         }
     }
+
     Ok(())
 }
 
@@ -637,13 +671,16 @@ fn disconnect_withdrawal_bundle_submitted(
             return Err(Error::UnknownWithdrawalBundle { m6id });
         }
     };
+
     let (bundle_status, latest_bundle_status) = bundle_status.pop();
+
     assert!(matches!(
         latest_bundle_status.value,
         WithdrawalBundleStatus::Submitted
             | WithdrawalBundleStatus::SubmittedUnexpected
     ));
     assert_eq!(latest_bundle_status.height, block_height);
+
     match &bundle {
         WithdrawalBundleInfo::Unknown
         | WithdrawalBundleInfo::UnknownConfirmed { .. } => (),
@@ -652,19 +689,20 @@ fn disconnect_withdrawal_bundle_submitted(
                 && bundle_status.latest().value
                     == WithdrawalBundleStatus::Pending
             {
-                for (outpoint, output) in bundle.spend_utxos().iter().rev() {
+                for outpoint in bundle.spend_utxos().keys().rev() {
                     let outpoint_key = OutPointKey::from_outpoint(outpoint);
-                    if !state.stxos.delete(rwtxn, &outpoint_key)? {
+                    if !state.unspend_utxo(rwtxn, &outpoint_key)? {
                         return Err(Error::NoStxo {
                             outpoint: *outpoint,
                         });
-                    };
-                    state.utxos.put(rwtxn, &outpoint_key, output)?;
+                    }
                 }
+
                 state.pending_withdrawal_bundle.put(rwtxn, &(), &m6id)?;
             }
         }
     }
+
     if let Some(bundle_status) = bundle_status {
         state
             .withdrawal_bundles
@@ -672,6 +710,7 @@ fn disconnect_withdrawal_bundle_submitted(
     } else {
         state.withdrawal_bundles.delete(rwtxn, &m6id)?;
     }
+
     Ok(())
 }
 
@@ -685,7 +724,9 @@ fn disconnect_withdrawal_bundle_confirmed(
         .withdrawal_bundles
         .try_get(rwtxn, &m6id)?
         .ok_or_else(|| Error::UnknownWithdrawalBundle { m6id })?;
+
     let (prev_bundle_status, latest_bundle_status) = bundle_status.pop();
+
     if matches!(
         latest_bundle_status.value,
         WithdrawalBundleStatus::Submitted
@@ -694,54 +735,59 @@ fn disconnect_withdrawal_bundle_confirmed(
         // Already applied
         return Ok(());
     }
+
     assert_eq!(
         latest_bundle_status.value,
         WithdrawalBundleStatus::Confirmed
     );
     assert_eq!(latest_bundle_status.height, block_height);
+
     let prev_bundle_status = prev_bundle_status
         .expect("Pop confirmed bundle status should be valid");
+
     assert!(matches!(
         prev_bundle_status.latest().value,
         WithdrawalBundleStatus::Submitted
             | WithdrawalBundleStatus::SubmittedUnexpected
     ));
+
     match &bundle {
         WithdrawalBundleInfo::Known(bundle) => {
             if matches!(
                 prev_bundle_status.latest().value,
                 WithdrawalBundleStatus::SubmittedUnexpected
             ) {
-                for (outpoint, output) in bundle.spend_utxos() {
-                    let outpoint_key = OutPointKey::from(outpoint);
-                    state.utxos.put(rwtxn, &outpoint_key, output)?;
-                    if !state.stxos.delete(rwtxn, &outpoint_key)? {
+                for outpoint in bundle.spend_utxos().keys() {
+                    let outpoint_key = OutPointKey::from_outpoint(outpoint);
+                    if !state.unspend_utxo(rwtxn, &outpoint_key)? {
                         return Err(Error::NoStxo {
                             outpoint: *outpoint,
                         });
-                    };
+                    }
                 }
             }
         }
         WithdrawalBundleInfo::UnknownConfirmed { spend_utxos } => {
-            for (outpoint, output) in spend_utxos {
+            for outpoint in spend_utxos.keys() {
                 let outpoint_key = OutPointKey::from_outpoint(outpoint);
-                state.utxos.put(rwtxn, &outpoint_key, output)?;
-                if !state.stxos.delete(rwtxn, &outpoint_key)? {
+                if !state.unspend_utxo(rwtxn, &outpoint_key)? {
                     return Err(Error::NoStxo {
                         outpoint: *outpoint,
                     });
-                };
+                }
             }
+
             bundle = WithdrawalBundleInfo::Unknown;
         }
         WithdrawalBundleInfo::Unknown => (),
     }
+
     state.withdrawal_bundles.put(
         rwtxn,
         &m6id,
         &(bundle, prev_bundle_status),
     )?;
+
     Ok(())
 }
 
@@ -755,21 +801,27 @@ fn disconnect_withdrawal_bundle_failed(
         .withdrawal_bundles
         .try_get(rwtxn, &m6id)?
         .ok_or_else(|| Error::UnknownWithdrawalBundle { m6id })?;
+
     let (prev_bundle_status, latest_bundle_status) = bundle_status.pop();
+
     if latest_bundle_status.value == WithdrawalBundleStatus::Submitted {
         // Already applied
         return Ok(());
     } else {
         assert_eq!(latest_bundle_status.value, WithdrawalBundleStatus::Failed);
     }
+
     assert_eq!(latest_bundle_status.height, block_height);
+
     let prev_bundle_status =
         prev_bundle_status.expect("Pop failed bundle status should be valid");
+
     assert!(matches!(
         prev_bundle_status.latest().value,
         WithdrawalBundleStatus::Submitted
             | WithdrawalBundleStatus::SubmittedUnexpected
     ));
+
     match &bundle {
         WithdrawalBundleInfo::Unknown
         | WithdrawalBundleInfo::UnknownConfirmed { .. } => (),
@@ -780,27 +832,26 @@ fn disconnect_withdrawal_bundle_failed(
             ) {
                 break 'known;
             }
+
             for (outpoint, output) in bundle.spend_utxos().iter().rev() {
-                let outpoint_key = OutPointKey::from_outpoint(outpoint);
-                let spent_output = SpentOutput {
-                    output: output.clone(),
-                    inpoint: InPoint::Withdrawal { m6id },
-                };
-                state.stxos.put(rwtxn, &outpoint_key, &spent_output)?;
-                if !state.utxos.delete(rwtxn, &outpoint_key)? {
+                if !spend_withdrawal_utxo(state, rwtxn, m6id, outpoint, output)?
+                {
                     return Err(error::NoUtxo {
                         outpoint: *outpoint,
                     }
                     .into());
-                };
+                }
             }
+
             let (prev_latest_failed_m6id, latest_failed_m6id) = state
                 .latest_failed_withdrawal_bundle
                 .try_get(rwtxn, &())?
                 .expect("latest failed withdrawal bundle should exist")
                 .pop();
+
             assert_eq!(latest_failed_m6id.value, m6id);
             assert_eq!(latest_failed_m6id.height, block_height);
+
             if let Some(prev_latest_failed_m6id) = prev_latest_failed_m6id {
                 state.latest_failed_withdrawal_bundle.put(
                     rwtxn,
@@ -812,12 +863,29 @@ fn disconnect_withdrawal_bundle_failed(
             }
         }
     }
+
     state.withdrawal_bundles.put(
         rwtxn,
         &m6id,
         &(bundle, prev_bundle_status),
     )?;
+
     Ok(())
+}
+
+fn spend_withdrawal_utxo(
+    state: &State,
+    rwtxn: &mut RwTxn,
+    m6id: M6id,
+    outpoint: &OutPoint,
+    output: &FilledOutput,
+) -> Result<bool, sneed::db::Error> {
+    let outpoint_key = OutPointKey::from_outpoint(outpoint);
+    let spent_output = SpentOutput {
+        output: output.clone(),
+        inpoint: InPoint::Withdrawal { m6id },
+    };
+    state.spend_utxo(rwtxn, outpoint_key, spent_output)
 }
 
 fn disconnect_withdrawal_bundle_event(
@@ -867,9 +935,13 @@ fn disconnect_event(
         BlockEvent::Deposit(deposit) => {
             let outpoint = OutPoint::Deposit(deposit.outpoint);
             let outpoint_key = OutPointKey::from_outpoint(&outpoint);
-            if !state.utxos.delete(rwtxn, &outpoint_key)? {
+            let address_key =
+                AddressOutPointKey::new(deposit.output.address, outpoint_key);
+
+            if !state.delete_utxo(rwtxn, &address_key)? {
                 return Err(error::NoUtxo { outpoint }.into());
             }
+
             // Blocks are iterated in reverse here, so the first event block
             // hash seen is the latest. Keep it to match what `connect` stored.
             if latest_deposit_block_hash.is_none() {
@@ -883,6 +955,7 @@ fn disconnect_event(
                 block_height,
                 withdrawal_bundle_event,
             )?;
+
             // Blocks are iterated in reverse here, so the first event block
             // hash seen is the latest. Keep it to match what `connect` stored.
             if latest_withdrawal_bundle_event_block_hash.is_none() {
@@ -891,6 +964,7 @@ fn disconnect_event(
             }
         }
     }
+
     Ok(())
 }
 
@@ -1065,7 +1139,7 @@ mod test {
                 &RollBack::<HeightStamped<_>>::new(m6id, 1),
             )?;
             // the failure reinstated the utxo
-            state.utxos.put(&mut rwtxn, &key, &output)?;
+            state.put_utxo(&mut rwtxn, key, output, 0)?;
             rwtxn.commit()?;
             m6id
         };
@@ -1074,7 +1148,7 @@ mod test {
         disconnect_withdrawal_bundle_failed(&state, &mut rwtxn, 1, m6id)?;
         anyhow::ensure!(state.utxos.try_get(&rwtxn, &key)?.is_none());
         let stxo = state.stxos.get(&rwtxn, &key)?;
-        anyhow::ensure!(stxo.inpoint == InPoint::Withdrawal { m6id });
+        anyhow::ensure!(stxo.output.inpoint == InPoint::Withdrawal { m6id });
         Ok(())
     }
 
@@ -1208,10 +1282,11 @@ mod test {
                     ),
                     memo: Vec::new(),
                 };
-                state.utxos.put(
+                state.put_utxo(
                     &mut rwtxn,
-                    &OutPointKey::from(&outpoint),
-                    &output,
+                    OutPointKey::from(&outpoint),
+                    output,
+                    0,
                 )?;
             }
             f(&state, &mut rwtxn)

--- a/lib/types/address.rs
+++ b/lib/types/address.rs
@@ -7,11 +7,13 @@ use utoipa::ToSchema;
 
 use crate::types::THIS_SIDECHAIN;
 
+pub const ADDRESS_SIZE: usize = 20;
+
 #[derive(Debug, Error)]
 pub enum AddressParseError {
     #[error("bs58 error")]
     Bs58(#[from] bitcoin::base58::InvalidCharacterError),
-    #[error("wrong address length {0} != 20")]
+    #[error("wrong address length {0} != {ADDRESS_SIZE}")]
     WrongLength(usize),
 }
 
@@ -20,10 +22,10 @@ pub enum AddressParseError {
 )]
 #[repr(transparent)]
 #[schema(value_type = String)]
-pub struct Address(pub [u8; 20]);
+pub struct Address(pub [u8; ADDRESS_SIZE]);
 
 impl Address {
-    pub const ALL_ZEROS: Self = Self([0; 20]);
+    pub const ALL_ZEROS: Self = Self([0; ADDRESS_SIZE]);
 
     pub fn as_base58(&self) -> String {
         bitcoin::base58::encode(&self.0)
@@ -50,8 +52,8 @@ impl std::fmt::Debug for Address {
     }
 }
 
-impl From<[u8; 20]> for Address {
-    fn from(other: [u8; 20]) -> Self {
+impl From<[u8; ADDRESS_SIZE]> for Address {
+    fn from(other: [u8; ADDRESS_SIZE]) -> Self {
         Self(other)
     }
 }
@@ -74,7 +76,8 @@ impl<'de> Deserialize<'de> for Address {
         if deserializer.is_human_readable() {
             DisplayFromStr::deserialize_as(deserializer)
         } else {
-            <[u8; 20] as Deserialize>::deserialize(deserializer).map(Self)
+            <[u8; ADDRESS_SIZE] as Deserialize>::deserialize(deserializer)
+                .map(Self)
         }
     }
 }

--- a/lib/types/hashes.rs
+++ b/lib/types/hashes.rs
@@ -455,3 +455,31 @@ where
         blake3::hash(&buffer).into()
     })
 }
+
+#[derive(Clone, Debug)]
+pub struct MerkleProof {
+    pub leaf_index: usize,
+    pub siblings: Vec<MerkleProofNode>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MerkleProofNode {
+    pub hash: Hash,
+    pub is_left: bool,
+}
+
+impl MerkleProof {
+    pub fn verify(&self, leaf: Hash, root: MerkleRoot) -> bool {
+        let mut hash = leaf;
+
+        for sibling in &self.siblings {
+            hash = if sibling.is_left {
+                hash_with_scratch_buffer(&(sibling.hash, hash))
+            } else {
+                hash_with_scratch_buffer(&(hash, sibling.hash))
+            };
+        }
+
+        hash == Hash::from(root)
+    }
+}

--- a/lib/types/hashes.rs
+++ b/lib/types/hashes.rs
@@ -456,13 +456,13 @@ where
     })
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MerkleProof {
     pub leaf_index: usize,
     pub siblings: Vec<MerkleProofNode>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct MerkleProofNode {
     pub hash: Hash,
     pub is_left: bool,

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -24,8 +24,8 @@ pub mod transaction;
 pub use address::Address;
 pub use bitasset_data::{BitAssetData, BitAssetDataUpdates, Update};
 pub use hashes::{
-    AssetId, BitAssetId, BlockHash, DutchAuctionId, Hash, M6id, MerkleRoot,
-    Txid,
+    AssetId, BitAssetId, BlockHash, DutchAuctionId, Hash, M6id, MerkleProof,
+    MerkleProofNode, MerkleRoot, Txid,
 };
 pub use keys::{EncryptionPubKey, VerifyingKey};
 pub use transaction::{
@@ -489,8 +489,62 @@ impl Body {
         coinbase: &[Output],
         txs: &[Transaction],
     ) -> MerkleRoot {
-        // FIXME: Compute actual merkle root instead of just a hash.
-        hashes::hash_with_scratch_buffer(&(coinbase, txs)).into()
+        let mut leaves = Vec::with_capacity(txs.len() + 1);
+        leaves.push(hashes::hash_with_scratch_buffer(&coinbase));
+        leaves.extend(txs.iter().map(hashes::hash_with_scratch_buffer));
+        Body::compute_cbmt_tree(&leaves)[0].into()
+    }
+
+    // https://github.com/nervosnetwork/merkle-tree/blob/5d1898263e7167560fdaa62f09e8d52991a1c712/README.md#tree-struct
+    fn compute_cbmt_tree(leaves: &[Hash]) -> Vec<Hash> {
+        let n = leaves.len();
+        let mut nodes = vec![Hash::default(); 2 * n - 1];
+
+        nodes[n - 1..].copy_from_slice(leaves);
+
+        for idx in (0..n - 1).rev() {
+            nodes[idx] = hashes::hash_with_scratch_buffer(&(
+                nodes[2 * idx + 1],
+                nodes[2 * idx + 2],
+            ));
+        }
+
+        nodes
+    }
+
+    pub fn compute_tx_merkle_proof(
+        coinbase: &[Output],
+        txs: &[Transaction],
+        tx_idx: usize,
+    ) -> MerkleProof {
+        let mut leaves = Vec::with_capacity(txs.len() + 1);
+        leaves.push(hashes::hash_with_scratch_buffer(&coinbase));
+        leaves.extend(txs.iter().map(hashes::hash_with_scratch_buffer));
+        Body::compute_cbmt_proof(&leaves, tx_idx + 1)
+    }
+
+    fn compute_cbmt_proof(leaves: &[Hash], leaf_index: usize) -> MerkleProof {
+        let n = leaves.len();
+        let nodes = Body::compute_cbmt_tree(leaves);
+        let mut idx = leaf_index + n - 1;
+        let mut siblings = Vec::new();
+
+        while idx > 0 {
+            let sibling_idx = (idx + 1) ^ 1;
+            let sibling_idx = sibling_idx - 1;
+
+            siblings.push(MerkleProofNode {
+                hash: nodes[sibling_idx],
+                is_left: sibling_idx < idx,
+            });
+
+            idx = (idx - 1) / 2;
+        }
+
+        MerkleProof {
+            leaf_index,
+            siblings,
+        }
     }
 
     pub fn get_inputs(&self) -> Vec<OutPoint> {
@@ -743,5 +797,53 @@ mod withdrawal_bundle_order_regression {
                 "m6id must not depend on aggregation order"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod merkle_tests {
+    use super::*;
+
+    fn tx(memo: &[u8]) -> Transaction {
+        let mut tx = Transaction::default();
+        tx.memo = memo.to_vec();
+        tx
+    }
+
+    #[test]
+    fn tx_merkle_proof_verifies_membership() {
+        let coinbase = Vec::new();
+        let txs = vec![tx(b"tx-0"), tx(b"tx-1"), tx(b"tx-2"), tx(b"tx-3")];
+
+        let root = Body::compute_merkle_root(&coinbase, &txs);
+        let proof = Body::compute_tx_merkle_proof(&coinbase, &txs, 2);
+        let leaf = hashes::hash_with_scratch_buffer(&txs[2]);
+
+        assert!(proof.verify(leaf, root));
+    }
+
+    #[test]
+    fn tx_merkle_proof_rejects_non_member() {
+        let coinbase = Vec::new();
+        let txs = vec![tx(b"tx-0"), tx(b"tx-1"), tx(b"tx-2"), tx(b"tx-3")];
+        let other = tx(b"other");
+
+        let root = Body::compute_merkle_root(&coinbase, &txs);
+        let proof = Body::compute_tx_merkle_proof(&coinbase, &txs, 2);
+        let leaf = hashes::hash_with_scratch_buffer(&other);
+
+        assert!(!proof.verify(leaf, root));
+    }
+
+    #[test]
+    fn tx_merkle_proof_rejects_wrong_position() {
+        let coinbase = Vec::new();
+        let txs = vec![tx(b"tx-0"), tx(b"tx-1"), tx(b"tx-2"), tx(b"tx-3")];
+
+        let root = Body::compute_merkle_root(&coinbase, &txs);
+        let proof = Body::compute_tx_merkle_proof(&coinbase, &txs, 2);
+        let leaf = hashes::hash_with_scratch_buffer(&txs[1]);
+
+        assert!(!proof.verify(leaf, root));
     }
 }

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -21,7 +21,7 @@ pub mod proto;
 pub mod schema;
 pub mod transaction;
 
-pub use address::Address;
+pub use address::{ADDRESS_SIZE, Address};
 pub use bitasset_data::{BitAssetData, BitAssetDataUpdates, Update};
 pub use hashes::{
     AssetId, BitAssetId, BlockHash, DutchAuctionId, Hash, M6id, MerkleProof,
@@ -29,8 +29,8 @@ pub use hashes::{
 };
 pub use keys::{EncryptionPubKey, VerifyingKey};
 pub use transaction::{
-    AmmBurn, AmmMint, AmmSwap, AssetOutput, AssetOutputContent, Authorized,
-    AuthorizedTransaction, BitcoinOutput, BitcoinOutputContent,
+    AddressTxidKey, AmmBurn, AmmMint, AmmSwap, AssetOutput, AssetOutputContent,
+    Authorized, AuthorizedTransaction, BitcoinOutput, BitcoinOutputContent,
     DutchAuctionBid, DutchAuctionCollect, DutchAuctionParams, FilledOutput,
     FilledOutputContent, FilledTransaction, InPoint, OutPoint, OutPointKey,
     Output, OutputContent, PointedOutput, SpentOutput, Transaction, TxData,

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -29,12 +29,12 @@ pub use hashes::{
 };
 pub use keys::{EncryptionPubKey, VerifyingKey};
 pub use transaction::{
-    AddressTxidKey, AmmBurn, AmmMint, AmmSwap, AssetOutput, AssetOutputContent,
-    Authorized, AuthorizedTransaction, BitcoinOutput, BitcoinOutputContent,
-    DutchAuctionBid, DutchAuctionCollect, DutchAuctionParams, FilledOutput,
-    FilledOutputContent, FilledTransaction, InPoint, OutPoint, OutPointKey,
-    Output, OutputContent, PointedOutput, SpentOutput, Transaction, TxData,
-    TxInputs, WithdrawalOutputContent,
+    AddressOutPointKey, AddressTxidKey, AmmBurn, AmmMint, AmmSwap, AssetOutput,
+    AssetOutputContent, Authorized, AuthorizedTransaction, BitcoinOutput,
+    BitcoinOutputContent, DutchAuctionBid, DutchAuctionCollect,
+    DutchAuctionParams, FilledOutput, FilledOutputContent, FilledTransaction,
+    InPoint, OutPoint, OutPointKey, Output, OutputContent, PointedOutput,
+    SpentOutput, Transaction, TxData, TxInputs, WithdrawalOutputContent,
 };
 
 pub const THIS_SIDECHAIN: u8 = 4;

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashMap},
+    io,
     sync::LazyLock,
 };
 
@@ -35,6 +36,11 @@ pub use transaction::{
     DutchAuctionParams, FilledOutput, FilledOutputContent, FilledTransaction,
     InPoint, OutPoint, OutPointKey, Output, OutputContent, PointedOutput,
     SpentOutput, Transaction, TxData, TxInputs, WithdrawalOutputContent,
+};
+
+use hashlink::{LinkedHashMap, linked_hash_map::Entry};
+use rustreexo::accumulator::{
+    mem_forest::MemForest, node_hash::AccumulatorHash,
 };
 
 pub const THIS_SIDECHAIN: u8 = 4;
@@ -800,6 +806,240 @@ mod withdrawal_bundle_order_regression {
     }
 }
 
+/// Hash type used by the Utreexo accumulator.
+///
+/// Concrete hashes are BLAKE3 digests. `Placeholder` and `Empty` are internal
+/// rustreexo sentinel values.
+///
+/// The encoding and `parent_hash` algorithm are consensus-critical.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Blake3UtxoHash {
+    Some([u8; 32]),
+    Placeholder,
+    #[default]
+    Empty,
+}
+
+impl Blake3UtxoHash {
+    pub fn hash_bytes(bytes: &[u8]) -> Self {
+        Self::Some(*blake3::hash(bytes).as_bytes())
+    }
+
+    pub fn as_bytes(&self) -> Option<[u8; 32]> {
+        match self {
+            Self::Some(bytes) => Some(*bytes),
+            Self::Placeholder | Self::Empty => None,
+        }
+    }
+}
+
+impl From<blake3::Hash> for Blake3UtxoHash {
+    fn from(hash: blake3::Hash) -> Self {
+        Self::Some(*hash.as_bytes())
+    }
+}
+
+impl From<[u8; 32]> for Blake3UtxoHash {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self::Some(bytes)
+    }
+}
+
+impl std::fmt::Display for Blake3UtxoHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Some(bytes) => write!(f, "{:?}", bytes),
+            Self::Placeholder => write!(f, "Placeholder"),
+            Self::Empty => write!(f, "Empty"),
+        }
+    }
+}
+
+impl AccumulatorHash for Blake3UtxoHash {
+    fn placeholder() -> Self {
+        Self::Placeholder
+    }
+
+    fn empty() -> Self {
+        Self::Empty
+    }
+
+    fn is_placeholder(&self) -> bool {
+        matches!(self, Self::Placeholder)
+    }
+
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    fn write<W>(&self, writer: &mut W) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        match self {
+            Self::Empty => writer.write_all(&[0]),
+            Self::Placeholder => writer.write_all(&[1]),
+            Self::Some(bytes) => {
+                writer.write_all(&[2])?;
+                writer.write_all(bytes)
+            }
+        }
+    }
+
+    fn read<R>(reader: &mut R) -> io::Result<Self>
+    where
+        R: io::Read,
+    {
+        let mut tag = [0];
+        reader.read_exact(&mut tag)?;
+
+        match tag {
+            [0] => Ok(Self::Empty),
+            [1] => Ok(Self::Placeholder),
+            [2] => {
+                let mut bytes = [0u8; 32];
+                reader.read_exact(&mut bytes)?;
+                Ok(Self::Some(bytes))
+            }
+            [_] => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected tag for Blake3UtxoHash",
+            )),
+        }
+    }
+
+    fn parent_hash(left: &Self, right: &Self) -> Self {
+        let (Self::Some(left), Self::Some(right)) = (left, right) else {
+            unreachable!("parent_hash called with non-concrete hash");
+        };
+
+        let mut input = [0u8; 64];
+        input[..32].copy_from_slice(left);
+        input[32..].copy_from_slice(right);
+
+        Self::Some(*blake3::hash(&input).as_bytes())
+    }
+}
+
+/// Hash a UTXO into the canonical leaf committed to by the accumulator.
+pub fn utreexo_leaf_hash(outpoint: &OutPoint, output: &FilledOutput) -> Hash {
+    hashes::hash_with_scratch_buffer(&PointedOutput {
+        outpoint: *outpoint,
+        output: output.clone(),
+    })
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AccumulatorDiff {
+    /// `true` means insertion; `false` means deletion.
+    diff: LinkedHashMap<[u8; 32], bool>,
+    insertions: usize,
+    deletions: usize,
+}
+
+impl AccumulatorDiff {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            diff: LinkedHashMap::with_capacity(capacity),
+            insertions: 0,
+            deletions: 0,
+        }
+    }
+
+    pub fn insert(&mut self, utxo_hash: [u8; 32]) {
+        match self.diff.entry(utxo_hash) {
+            Entry::Occupied(entry) => {
+                if !entry.get() {
+                    entry.remove();
+                    debug_assert!(self.deletions > 0);
+                    self.deletions -= 1;
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(true);
+                self.insertions += 1;
+            }
+        }
+    }
+
+    pub fn remove(&mut self, utxo_hash: [u8; 32]) {
+        match self.diff.entry(utxo_hash) {
+            Entry::Occupied(entry) => {
+                if *entry.get() {
+                    entry.remove();
+                    debug_assert!(self.insertions > 0);
+                    self.insertions -= 1;
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(false);
+                self.deletions += 1;
+            }
+        }
+    }
+}
+
+impl Serialize for AccumulatorDiff {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut insertions = Vec::with_capacity(self.insertions);
+        let mut deletions = Vec::with_capacity(self.deletions);
+
+        for (hash, insert) in &self.diff {
+            if *insert {
+                insertions.push(*hash);
+            } else {
+                deletions.push(*hash);
+            }
+        }
+
+        serde::Serialize::serialize(&(insertions, deletions), serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AccumulatorDiff {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let (insertions, deletions): (Vec<[u8; 32]>, Vec<[u8; 32]>) =
+            Deserialize::deserialize(deserializer)?;
+
+        let mut diff = Self::with_capacity(insertions.len() + deletions.len());
+
+        for hash in insertions {
+            diff.insert(hash);
+        }
+
+        for hash in deletions {
+            diff.remove(hash);
+        }
+
+        Ok(diff)
+    }
+}
+
+#[derive(Default)]
+#[repr(transparent)]
+pub struct Accumulator(pub MemForest<Blake3UtxoHash>);
+
+impl Accumulator {
+    pub fn serialize_into<W: io::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<(), String> {
+        self.0.serialize(writer).map_err(|err| err.to_string())
+    }
+
+    pub fn deserialize_from(bytes: &[u8]) -> Result<Self, String> {
+        MemForest::deserialize(bytes)
+            .map(Self)
+            .map_err(|err| err.to_string())
+    }
+}
+
 #[cfg(test)]
 mod merkle_tests {
     use super::*;
@@ -845,5 +1085,91 @@ mod merkle_tests {
         let leaf = hashes::hash_with_scratch_buffer(&txs[1]);
 
         assert!(!proof.verify(leaf, root));
+    }
+}
+
+#[cfg(test)]
+mod utreexo_hash_tests {
+    use rustreexo::accumulator::node_hash::AccumulatorHash as _;
+
+    use super::{
+        Accumulator, AccumulatorDiff, Address, Blake3UtxoHash, FilledOutput,
+        FilledOutputContent, OutPoint, utreexo_leaf_hash,
+    };
+
+    #[test]
+    fn accumulator_hash_tags_roundtrip_distinct_sentinels() {
+        for expected in [
+            Blake3UtxoHash::Empty,
+            Blake3UtxoHash::Placeholder,
+            Blake3UtxoHash::Some([0; 32]),
+            Blake3UtxoHash::Some([42; 32]),
+        ] {
+            let mut bytes = Vec::new();
+            expected.write(&mut bytes).unwrap();
+
+            let actual = Blake3UtxoHash::read(&mut &*bytes).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn accumulator_parent_hash_golden_vector() {
+        let parent = Blake3UtxoHash::parent_hash(
+            &Blake3UtxoHash::Some([1; 32]),
+            &Blake3UtxoHash::Some([2; 32]),
+        );
+
+        assert_eq!(
+            hex::encode(parent.as_bytes().unwrap()),
+            "8d67bc7836d128b108be2c965538f37bbcee3e7503e35e58fbb0446432e05206"
+        );
+    }
+
+    #[test]
+    fn accumulator_storage_formats_roundtrip() {
+        let mut expected_diff = AccumulatorDiff::default();
+        expected_diff.insert([1; 32]);
+        expected_diff.remove([2; 32]);
+
+        let encoded_diff = bincode::serialize(&expected_diff).unwrap();
+        let decoded_diff: AccumulatorDiff =
+            bincode::deserialize(&encoded_diff).unwrap();
+        assert_eq!(decoded_diff, expected_diff);
+
+        let expected_accumulator = Accumulator::default();
+        let mut encoded_accumulator = Vec::new();
+        expected_accumulator
+            .serialize_into(&mut encoded_accumulator)
+            .unwrap();
+
+        let decoded_accumulator =
+            Accumulator::deserialize_from(&encoded_accumulator).unwrap();
+        let mut reencoded_accumulator = Vec::new();
+        decoded_accumulator
+            .serialize_into(&mut reencoded_accumulator)
+            .unwrap();
+        assert_eq!(reencoded_accumulator, encoded_accumulator);
+    }
+
+    #[test]
+    fn utreexo_leaf_hash_golden_vector() {
+        let outpoint = OutPoint::Regular {
+            txid: [1; 32].into(),
+            vout: 7,
+        };
+        let output = FilledOutput {
+            address: Address::ALL_ZEROS,
+            content: FilledOutputContent::new_bitcoin_value(
+                bitcoin::Amount::from_sat(42),
+            ),
+            memo: b"utreexo".to_vec(),
+        };
+
+        assert_eq!(
+            hex::encode(utreexo_leaf_hash(&outpoint, &output)),
+            "3d6f84894a0d7586c1fdc5c7f42f3268aedef0f14a97633241bab06c66ccbb19"
+        );
     }
 }

--- a/lib/types/transaction/mod.rs
+++ b/lib/types/transaction/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, Cow},
     cmp::Ordering,
     collections::{HashMap, HashSet},
     io::Cursor,
@@ -17,7 +17,7 @@ use crate::{
     types::{
         AmountOverflowError, BitAssetData, BitAssetDataUpdates, GetAddress,
         GetBitcoinValue,
-        address::Address,
+        address::{ADDRESS_SIZE, Address},
         hashes::{
             self, AssetId, BitAssetId, DutchAuctionId, Hash, M6id, MerkleRoot,
             Txid,
@@ -1663,5 +1663,79 @@ impl From<Authorized<FilledTransaction>> for AuthorizedTransaction {
             transaction: tx.transaction.transaction,
             authorizations: tx.authorizations,
         }
+    }
+}
+
+const TXID_SIZE: usize = blake3::OUT_LEN;
+const ADDR_TXID_DB_KEY_SIZE: usize = ADDRESS_SIZE + TXID_SIZE;
+
+/// Fixed-width txdb key: address || txid.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AddressTxidKey([u8; ADDR_TXID_DB_KEY_SIZE]);
+
+impl AddressTxidKey {
+    #[inline]
+    pub fn new(address: Address, txid: Txid) -> Self {
+        let mut key = [0u8; ADDR_TXID_DB_KEY_SIZE];
+        key[..ADDRESS_SIZE].copy_from_slice(&address.0);
+        key[ADDRESS_SIZE..].copy_from_slice(txid.as_slice());
+        Self(key)
+    }
+
+    #[inline]
+    pub fn start(address: Address) -> Self {
+        let mut key = [0u8; ADDR_TXID_DB_KEY_SIZE];
+        key[..ADDRESS_SIZE].copy_from_slice(&address.0);
+        Self(key)
+    }
+
+    #[inline]
+    pub fn end(address: Address) -> Self {
+        let mut key = [0xffu8; ADDR_TXID_DB_KEY_SIZE];
+        key[..ADDRESS_SIZE].copy_from_slice(&address.0);
+        Self(key)
+    }
+
+    #[inline]
+    pub fn address(&self) -> Address {
+        let mut address = [0u8; ADDRESS_SIZE];
+        address.copy_from_slice(&self.0[..ADDRESS_SIZE]);
+        Address(address)
+    }
+
+    #[inline]
+    pub fn txid(&self) -> Txid {
+        let mut txid = [0u8; TXID_SIZE];
+        txid.copy_from_slice(&self.0[ADDRESS_SIZE..]);
+        Txid(txid)
+    }
+}
+
+impl AsRef<[u8]> for AddressTxidKey {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'a> BytesEncode<'a> for AddressTxidKey {
+    type EItem = AddressTxidKey;
+
+    #[inline]
+    fn bytes_encode(
+        item: &'a Self::EItem,
+    ) -> Result<Cow<'a, [u8]>, BoxedError> {
+        Ok(Cow::Borrowed(item.as_ref()))
+    }
+}
+
+impl<'a> BytesDecode<'a> for AddressTxidKey {
+    type DItem = AddressTxidKey;
+
+    #[inline]
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        let mut key = [0u8; ADDR_TXID_DB_KEY_SIZE];
+        key.copy_from_slice(bytes);
+        Ok(Self(key))
     }
 }

--- a/lib/types/transaction/mod.rs
+++ b/lib/types/transaction/mod.rs
@@ -1739,3 +1739,89 @@ impl<'a> BytesDecode<'a> for AddressTxidKey {
         Ok(Self(key))
     }
 }
+
+const ADDRESS_OUTPOINT_KEY_SIZE: usize = ADDRESS_SIZE + OUTPOINT_KEY_SIZE;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct AddressOutPointKey([u8; ADDRESS_OUTPOINT_KEY_SIZE]);
+
+impl AddressOutPointKey {
+    #[inline]
+    pub fn new(address: Address, outpoint: OutPointKey) -> Self {
+        let mut bytes = [0u8; ADDRESS_OUTPOINT_KEY_SIZE];
+        bytes[..ADDRESS_SIZE].copy_from_slice(&address.0);
+        bytes[ADDRESS_SIZE..].copy_from_slice(outpoint.as_bytes());
+        Self(bytes)
+    }
+
+    #[inline]
+    pub fn start(address: Address) -> Self {
+        let mut bytes = [0u8; ADDRESS_OUTPOINT_KEY_SIZE];
+        bytes[..ADDRESS_SIZE].copy_from_slice(&address.0);
+        Self(bytes)
+    }
+
+    #[inline]
+    pub fn end(address: Address) -> Self {
+        let mut bytes = [0xffu8; ADDRESS_OUTPOINT_KEY_SIZE];
+        bytes[..ADDRESS_SIZE].copy_from_slice(&address.0);
+        Self(bytes)
+    }
+
+    #[inline]
+    pub fn address(&self) -> Address {
+        let mut address = [0u8; ADDRESS_SIZE];
+        address.copy_from_slice(&self.0[..ADDRESS_SIZE]);
+        Address(address)
+    }
+
+    #[inline]
+    pub fn outpoint_key(&self) -> OutPointKey {
+        <OutPointKey as BytesDecode>::bytes_decode(&self.0[ADDRESS_SIZE..])
+            .expect("AddressOutPointKey should contain a valid OutPointKey")
+    }
+}
+
+impl Ord for AddressOutPointKey {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for AddressOutPointKey {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl AsRef<[u8]> for AddressOutPointKey {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'a> BytesEncode<'a> for AddressOutPointKey {
+    type EItem = AddressOutPointKey;
+
+    #[inline]
+    fn bytes_encode(
+        item: &'a Self::EItem,
+    ) -> Result<Cow<'a, [u8]>, BoxedError> {
+        Ok(Cow::Borrowed(item.as_ref()))
+    }
+}
+
+impl<'a> BytesDecode<'a> for AddressOutPointKey {
+    type DItem = AddressOutPointKey;
+
+    #[inline]
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        <OutPointKey as BytesDecode>::bytes_decode(&bytes[ADDRESS_SIZE..])?;
+        let mut key = [0u8; ADDRESS_OUTPOINT_KEY_SIZE];
+        key.copy_from_slice(bytes);
+        Ok(Self(key))
+    }
+}

--- a/lib/types/transaction/output.rs
+++ b/lib/types/transaction/output.rs
@@ -605,6 +605,7 @@ mod filled_content {
     FilledContent!(
         pub FilledContent,
         attrs: [derive(
+            borsh::BorshSerialize,
             Clone,
             Debug,
             Eq,


### PR DESCRIPTION
This is a second, more structured attempt to address three related areas:

- Full-node Utreexo accumulator handling.
- A consensus-defined block-header commitment to compact chain state, including state not derivable from UTXOs, such as active AMMs and auctions, open for future extensions, intended for fast full node sync.
- Full-node support for lite wallets.

This began as lite-wallet work, but all three depend on the same consensus-critical state commitment, which should be defined first.

**Plan**
-----------

1. Define storage formats suited to Utreexo and lite-wallet queries.
2. Define an extensible compact-state bundle for fast, trust-less initial sync; commit to it in block headers and add network transfer.
3. Add lite-wallet data formats and protocol support.