### PR TITLE
Add a version field to block header

### DIFF
--- a/app/app.rs
+++ b/app/app.rs
@@ -7,8 +7,9 @@ use plain_bitassets::{
     miner::{self, Miner},
     node::{self, Node},
     types::{
-        self, Address, AmountOverflowError, BitcoinOutputContent, Body,
-        FilledOutput, OutPoint, Output, Transaction,
+        self, Address, AmountOverflowError, BLOCK_HEADER_VERSION,
+        BitcoinOutputContent, Body, FilledOutput, OutPoint, Output,
+        Transaction,
         proto::mainchain::{
             self,
             generated::{validator_service_server, wallet_service_server},
@@ -439,6 +440,7 @@ impl App {
                 coinbase,
             );
             let header = types::Header {
+                version: BLOCK_HEADER_VERSION,
                 merkle_root,
                 prev_side_hash,
                 prev_main_hash,
@@ -456,6 +458,7 @@ impl App {
             let merkle_root = Body::compute_merkle_root(&coinbase, &[]);
             let body = Body::new(Vec::new(), coinbase);
             let header = types::Header {
+                version: BLOCK_HEADER_VERSION,
                 merkle_root,
                 prev_side_hash,
                 prev_main_hash,

--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -6,10 +6,10 @@ use sneed::{RoTxn, RwTxn};
 use crate::{
     state::{Error, PrevalidatedBlock, State, amm, dutch_auction, error},
     types::{
-        AmountOverflowError, Authorization, BitAssetId, Body, FilledOutput,
-        FilledOutputContent, GetAddress as _, GetBitcoinValue as _, Header,
-        InPoint, OutPoint, OutPointKey, OutputContent, SpentOutput, TxData,
-        Verify as _,
+        AmountOverflowError, Authorization, BLOCK_HEADER_VERSION, BitAssetId,
+        Body, FilledOutput, FilledOutputContent, GetAddress as _,
+        GetBitcoinValue as _, Header, InPoint, OutPoint, OutPointKey,
+        OutputContent, SpentOutput, TxData, Verify as _,
     },
 };
 
@@ -45,6 +45,8 @@ pub fn validate(
         let err = Error::InvalidBody {
             expected: header.merkle_root,
             computed: merkle_root,
+            local_header_version: BLOCK_HEADER_VERSION,
+            block_header_version: header.version,
         };
         return Err(err);
     }
@@ -124,6 +126,8 @@ pub fn prevalidate(
         let err = Error::InvalidBody {
             expected: header.merkle_root,
             computed: computed_merkle_root,
+            local_header_version: BLOCK_HEADER_VERSION,
+            block_header_version: header.version,
         };
         return Err(err);
     }
@@ -412,6 +416,8 @@ pub fn connect(
         let err = Error::InvalidBody {
             expected: merkle_root,
             computed: header.merkle_root,
+            local_header_version: BLOCK_HEADER_VERSION,
+            block_header_version: header.version,
         };
         return Err(err);
     }
@@ -574,6 +580,8 @@ pub fn disconnect_tip(
         let err = Error::InvalidBody {
             expected: header.merkle_root,
             computed: merkle_root,
+            local_header_version: BLOCK_HEADER_VERSION,
+            block_header_version: header.version,
         };
         return Err(err);
     }
@@ -726,14 +734,16 @@ mod test {
             test::fresh_state,
         },
         types::{
-            BitAssetData, BitAssetDataUpdates, BitAssetId, BlockHash, Body,
-            FilledOutput, FilledOutputContent, Hash, Header, OutPoint,
-            OutPointKey, Output, OutputContent, Transaction, TxData, Update,
+            BLOCK_HEADER_VERSION, BitAssetData, BitAssetDataUpdates,
+            BitAssetId, BlockHash, Body, FilledOutput, FilledOutputContent,
+            Hash, Header, OutPoint, OutPointKey, Output, OutputContent,
+            Transaction, TxData, Update,
         },
     };
 
     fn header(prev_side_hash: Option<BlockHash>, body: &Body) -> Header {
         Header {
+            version: BLOCK_HEADER_VERSION,
             merkle_root: Body::compute_merkle_root(
                 &body.coinbase,
                 &body.transactions,

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -136,7 +136,7 @@ pub mod dutch_auction {
         #[error("Invalid tx; Final price cannot be greater than initial price")]
         FinalPrice,
         #[error(
-            "Invalid tx; For a single-block auction, 
+            "Invalid tx; For a single-block auction,
                 final price must be exactly equal to initial price"
         )]
         PriceMismatch,
@@ -374,6 +374,8 @@ pub enum Error {
     InvalidBody {
         expected: MerkleRoot,
         computed: MerkleRoot,
+        local_header_version: u8,
+        block_header_version: u8,
     },
     #[error("invalid header: {0}")]
     InvalidHeader(InvalidHeader),

--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -1015,8 +1015,8 @@ mod test {
             },
         },
         types::{
-            Address, FilledOutput, FilledOutputContent, InPoint, M6id,
-            OutPoint, OutPointKey, Txid, WithdrawalBundle,
+            Address, BLOCK_HEADER_VERSION, FilledOutput, FilledOutputContent,
+            InPoint, M6id, OutPoint, OutPointKey, Txid, WithdrawalBundle,
             WithdrawalBundleEvent, WithdrawalBundleEventStatus,
             WithdrawalBundleStatus, WithdrawalOutputContent,
             proto::mainchain::{BlockEvent, BlockInfo, Deposit, TwoWayPegData},
@@ -1269,6 +1269,7 @@ mod test {
         let main1 = bitcoin::BlockHash::from_byte_array([11; 32]);
 
         let genesis = Header {
+            version: BLOCK_HEADER_VERSION,
             merkle_root,
             prev_side_hash: None,
             prev_main_hash: main0,
@@ -1284,6 +1285,7 @@ mod test {
         }
 
         let block1 = Header {
+            version: BLOCK_HEADER_VERSION,
             merkle_root,
             prev_side_hash: Some(genesis.hash()),
             prev_main_hash: main1,

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -38,6 +38,7 @@ pub use transaction::{
 };
 
 pub const THIS_SIDECHAIN: u8 = 4;
+pub const BLOCK_HEADER_VERSION: u8 = 0;
 
 #[derive(Debug, Error)]
 #[error("Bitcoin amount overflow")]
@@ -158,6 +159,7 @@ where
     ToSchema,
 )]
 pub struct Header {
+    pub version: u8,
     pub merkle_root: MerkleRoot,
     pub prev_side_hash: Option<BlockHash>,
     #[borsh(serialize_with = "borsh_serialize_bitcoin_block_hash")]


### PR DESCRIPTION
What is this for
--------------------

This is a first step towards some kind of strategy for handling consensus-changing network upgrades.

It could look as follows:
- Whenever there is a change which affects the way a block hash is constructed we also update a version number.
- Older node disregards a higher version number and tries to validate a block according to its rules, it may or may not work; on failure we include a version difference in error message, which works as a hint that network has moved on and this node has been left behind.
- Newer node retains previous versions' validation rules and verifies a block produced by older nodes according to old rules.

This way upgraded nodes will still be accepting older blocks, but once a breaking version block hash is included in L1 all older nodes progression will effectively be halted with an appropriate error message. 

I guess overall this is akin to hard-fork upgrade strategy where older network part is just commanded to upgrade to new rules by upgraded network part, because L1 agrees with an upgrade by including its block hashes. While this is inappropriate for L1 it may be a suitable strategy for a side-chain.

Why was this added
---------------------------

First practical example is https://github.com/LayerTwo-Labs/plain-bitassets/pull/57 where one of the main goals is to introduce a fast full node sync based on header commitments to block txs, utreexo memforest, AMMs, auctions etc. while currently header only commits to block txs.

In future more UTXO types may be added as well as breaking validation rules may be introduced, which will be reflected in version number.